### PR TITLE
bug fix - checkboxes not checked if true (Y)

### DIFF
--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -396,8 +396,8 @@ class Form_Field_Search extends Form_Field {
 	}
 }
 class Form_Field_Checkbox extends Form_Field {
-    public $true_value=1;
-    public $false_value=0;
+    public $true_values=array(1,'Y');
+    public $false_values=array(0,'N');
 	function init(){
 		parent::init();
 		$this->default_value='';
@@ -415,15 +415,15 @@ class Form_Field_Checkbox extends Form_Field {
 					array(
 						'type'=>'checkbox',
 						'value'=>$this->true_value,
-						'checked'=>(boolean)($this->true_value==$this->value)
+						'checked'=>(boolean)(in_array($this->value,$this->true_values))
 					     ),$attr
 					)).' &ndash; '.$label;
 	}
 	function loadPOST(){
 		if(isset($_POST[$this->name])){
-			$this->set($this->true_value);
+			$this->set($this->true_values[0]);
 		}else{
-			$this->set($this->false_value);
+			$this->set($this->false_values[0]);
 		}
 	}
 }


### PR DESCRIPTION
...e schema generator in atk-addons also uses ENUM('Y','N') then we need to check against 1 and Y for true values.

This was causing a bug where checkboxes would not be checked in mvc forms even if the value is true (Y) in the database (which is the default having used the schemagenerator).
