### PR TITLE
The <br/> was being parsed by htmlspecilchars or other parsing function ...

### DIFF
--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -528,7 +528,7 @@ class Form_Field_Text extends Form_Field {
 		parent::init();
 	}
 	function setFieldHint($text){
-		return parent::setFieldHint('<br/>'.$text);
+		return parent::setFieldHint($text);
 	}
 	function getInput($attr=array()){
 


### PR DESCRIPTION
...and therefore showing as "<br/>" rather than a new line. Textarea's should be rendered as a block element so don't need a <br/> to seperate the hint anyway.
