### PR TITLE
Fix titleQuery SELECT with unique table alias, issue #75

### DIFF
--- a/lib/Model/Table.php
+++ b/lib/Model/Table.php
@@ -155,12 +155,21 @@ class Model_Table extends Model {
     }
     /** Returns query which selects title field */
     function titleQuery(){
-        $query=$this->dsql()->del('fields');
+        // Create new model object and set unique alias for it
+        $m = $this->newInstance();
+        $a = array($this->table=>true);
+        if($this->table_alias) $a[$this->table_alias]=true;
+        $m->table_alias = $m->_unique($a,$m->table);
+
+        // Create title query
+        $query = $m->dsql()->del('fields');
         if($this->title_field && $this->hasElement($this->title_field)){
             $this->getElement($this->title_field)->updateSelectQuery($query);
-            return $query;
+        } else {
+            $query->field($query->expr('concat("Record #",'.$query->bt($this->_dsql()->getField($this->id_field)).')'));
         }
-        return $query->field($query->expr('concat("Record #",'.$query->bt($this->_dsql()->getField($this->id_field)).')'));
+
+        return $query;
     }
     // }}}
 


### PR DESCRIPTION
Before titleQuery function generated SELECT like this:
SELECT `name` FROM `t1` WHERE `t2`.`parent_id`=`t1`.`id`
this was ok in ordinary models, but not in hierarchial ones where t1=t2:
SELECT `name` FROM `t` WHERE `t`.`parent_id`=`t`.`id`

Now after this fix it'll be something like this with unique generated table alias t_2:
SELECT `name` FROM `t` `t_2` WHERE `t`.`parent_id`=`t_2`.`id`
which should be correct.

This fixes ATK4 issue #75 reported by me some time ago. No more ParentObject model walkaround is required.
