### PR TITLE
Update lib/Filter.php

### DIFF
--- a/lib/Filter.php
+++ b/lib/Filter.php
@@ -67,9 +67,11 @@ class Filter extends Form {
 	}
 	function submitted(){
 		if(parent::submitted()){
+			/* Imants: These rows are useless because forgetting is done inside memorizeAll
 			if($this->isClicked('Clear')){
 				$this->clearData();
 			}
+			*/
 			$this->memorizeAll();
             $this->view->js()->reload()->execute();
 		}


### PR DESCRIPTION
These rows are useless because forgetting is done inside memorizeAll.
Actually they can be even harmful if you use Clear button in form, because clearData() method doesn't exist at all.
