### PR TITLE
Update lib/View/Tabs/jUItabs.php

### DIFF
--- a/lib/View/Tabs/jUItabs.php
+++ b/lib/View/Tabs/jUItabs.php
@@ -19,17 +19,15 @@ class View_Tabs_jUItabs extends View_Tabs {
         parent::init();
         $this->tab_template=$this->template->cloneRegion('tabs');
         $this->template->del('tabs');
-        $this->js(true)
-            ->tabs($this->options);
     }
-    /* Set tabs option, for example, 'selected'=>'zero-based index of tab or ID of tab panel or href' */
+    /* Set tabs option, for example, 'selected'=>'zero-based index of tab */
     function setOption($key,$value){
         $this->options[$key]=$value;
         return $this;
     }
     function render(){
         $this->js(true)
-            ->tabs('option',$this->options);
+            ->tabs($this->options);
 
         return parent::render();
     }


### PR DESCRIPTION
1) We need to call ->tabs() on init method to initialize them. Otherwise it's impossible to interact with tabs widget between initialization and rendering.
2) Replaced setSelect with more general setOption which can be used like ->setOption('selected','index_of_tab_or_id_of_tab_panel). If we don't initialize tabs() widget in init method, then JUI doesn't understand tabs panel #id as 'selected' option.
3) In render() added ->tabs('option',...). It's not so important, because I guess it's used in JUI tabs by default, but... that way it looks nicer :)

Tested this and now it's working for me in both cases - when using zero-based index or id of tab panel as selected value.
