### PR TITLE
Update templates/js/start-atk4.js

### DIFF
--- a/templates/js/start-atk4.js
+++ b/templates/js/start-atk4.js
@@ -333,28 +333,17 @@ $.extend($.atk4,{
         head.appendChild(script);
     },
 	/*
-	 WARNING: this function will include CSS file in global context,
-	 which means relative paths will be counted from current directory
-	 and not the URL of the CSS file. This breaks url(../images) in
-	 CSS files
-
-	 This function will dynamically load CSS file
+	 This function will dynamically load CSS file.
+	 Also relative URLs like url(../images) will not break.
 	*/
     includeCSS: function(url){
-        if(this._isIncluded(url))return;
+		if(this._isIncluded(url))return;
 
-        this.get(url,function(code){
-            var cssTag = document.createElement('style');
-            cssTag.setAttribute('type', 'text/css');
-			if(cssTag.styleSheet){ // IE quirk
-				cssTag.styleSheet.cssText=code;
-			}else{	 // compliant browsers
-            	var t = document.createTextNode(code);
-				cssTag.appendChild(t);
-			}
-            var headerTag = document.getElementsByTagName('head')[0];
-            headerTag.appendChild(cssTag);
-        });
+		$("<link>", {
+			rel: "stylesheet",
+			type: "text/css",
+			href: url
+		}).appendTo("head");
     },
     _isIncluded: function(url){
         if(this._includes[url])return true;


### PR DESCRIPTION
This fix will resolve problems with dynamically including CSS files. Till now they was included as <style>...</style> in global context in document head. That breaks relative URLs in CSS file which we like to use almost everywhere.
So, the fix is simple - don't include CSS code directly into head, but include link to that stylesheet into head. Then nothing breaks and relative URLs in CSS file works as clock.

I don't see any drawback of this, because one extra request for CSS file is made anyway.
As far as I tested it - it works.

I'll publish small changes in autocomplete addon in a minute and then you'll be able to see how I use this. I can simply include CSS file like this and nothing breaks:
        $this->other_field->js(true)
            ->_load('autocomplete_univ')
            ->_css('autocomplete') // loads properly now
            ->univ()->myautocomplete($url, $this, $this->options);
