### PR TITLE
Fix for DSQL order

### DIFF
--- a/lib/DB/dsql.php
+++ b/lib/DB/dsql.php
@@ -575,10 +575,13 @@ class DB_dsql extends AbstractModel implements Iterator {
     }
     // }}}
     // {{{ order()
-    function order($order,$desc=null){// ,$prepend=null){
-        if(is_object($order))$order='('.$order.')';
-        if($desc)$order.=' desc';
-        return $this->_setArray($order,'order');
+    function order($order,$desc=null,$parse_commas=true){// ,$prepend=null){
+		if(is_object($order)){
+			$order='('.$order.')';
+			$parse_commas=false;
+		}
+		if($desc && strtolower($desc)!='asc') $order.=' desc';
+		return $this->_setArray($order,'order',$parse_commas);
     }
 
     function render_order(){


### PR DESCRIPTION
1) Allows to use ->order(field,'asc') too. I believe that's useful feature because I can't stop writing model->setOrder(field,'desc') and setOrder(field,'asc')... I made mistakes with this 3 times already and spent almost hour to find the reason :)

2) Fix for ordering. Now it don't parse commas if received field is not an object. For example, if it's expression made in model_table->setOrder with field->getExpr().
Till now it was not possible to sort model data by expression field if expression contained commas ( for example, concat(name,' ',surname) ).
Probably it's possible to set $parse_commas=false always no matter what type of $order variable we get, but I guess this approach is a bit better because I'm not sure which classes call this order() method and maybe some use 'field1,field2,field3' approach.
