### PR TITLE
Exception if PDO is enabled, but PDO_MySQL is not

### DIFF
--- a/lib/DB.php
+++ b/lib/DB.php
@@ -46,6 +46,9 @@ class DB extends AbstractController {
                 // don't be too worried about properly parsing it
                 preg_match('|([a-z]+)://([^:]*)(:(.*))?@([A-Za-z0-9\.-]*)(/([0-9a-zA-Z_/\.]*))|',$dsn,$matches);
 
+				// check if PDO_MySQL is enabled
+				if (!defined('PDO::MYSQL_ATTR_INIT_COMMAND'))
+					throw $this->exception('PDO_MYSQL unavailable',DB);
 
                 $dsn=array(
                     $matches[1].':host='.$matches[5].';dbname='.$matches[7].


### PR DESCRIPTION
If PDO is enabled, but PDO_MySQL is not enabled in your server, then we simply get HTTP 500 error response on line with PDO::MYSQL_ATTR_INIT_COMMAND without any explanation why it's so.
Better throw exception and explain what's happening.
