### PR TITLE
Update lib/Controller/MVCForm.php

### DIFF
--- a/lib/Controller/MVCForm.php
+++ b/lib/Controller/MVCForm.php
@@ -109,7 +109,8 @@ class Controller_MVCForm extends AbstractController {
         if($field->theModel){
             $form_field->setModel($field->theModel);
         }
-        if($form_field instanceof Form_Field_ValueList)$form_field->setEmptyText($field->emptyText());
+        if($form_field instanceof Form_Field_ValueList && !$field->mandatory() && $field->defaultValue()!==null)
+            $form_field->setEmptyText($field->emptyText());
 
         return $form_field;
     }


### PR DESCRIPTION
Option "Please select" in dropdown and radio fields (value lists) was shown even if associated model field had both mandatory()+defaultValue() set.
I believe in such situation it's completely useless and even wrong.
