### PR TITLE
Image/icon vertical position in gridtable cell

### DIFF
--- a/templates/shared/css/atk-main.css
+++ b/templates/shared/css/atk-main.css
@@ -996,6 +996,9 @@ textarea:focus {
   border-bottom: 1px solid #e5e5e5;
   padding: 0.6666666666666666em;
 }
+.atk-grid > table > tbody > tr > td > img {
+  vertical-align: middle;
+}
 .atk-grid > table > tbody > tr > td .atk-dropmenu {
   filter: alpha(opacity=0);
   -khtml-opacity: 0;

--- a/templates/shared/css/atk-main.less
+++ b/templates/shared/css/atk-main.less
@@ -601,6 +601,7 @@ textarea:focus {
 		width:100%;
 		>thead>tr>th {border:none;text-align:left;padding:@padding/5 @padding/3;}
 		>tbody>tr>td {border-bottom:1px solid @border;padding:@padding/3;}
+		>tbody>tr>td>img {vertical-align: middle;}
 		>tbody>tr>td .atk-dropmenu {.opacity(0);}
 		>tbody>tr:hover>td .atk-dropmenu {
 			.transition(opacity @transition);


### PR DESCRIPTION
Without this images (for example small icons) in grid table cell was positioned with default `vertical-align: baseline;` and that's not good because images was not vertically centered in table cell and as result make table cells much higher that they should be.
