### PR TITLE
Paginator template fix

### DIFF
--- a/templates/shared/grid.html
+++ b/templates/shared/grid.html
@@ -40,10 +40,9 @@
 
 
     </tbody>
-    <?full_table?>
-    <?/full_table?>
+    <?$full_table?>
   </table>
   <?not_found?><div class="atk-grid-notfound ui-state-highlight ui-corner-all"><i class="ui-icon ui-icon-alert float-left"></i>No Records Found</div><?/not_found?>
-  <div class="atk-paginator"><?paginator?><?/?></div>
-  <?hidden_forms?><?/hidden_forms?>
+  <?$paginator?>
+  <?$hidden_forms?>
 </div>


### PR DESCRIPTION
Fixed: https://github.com/atk4/atk4/issues/73
<div atk-paginator> was always added to grid because it was defined in template and because of css padding it was also visible.
Paginator class adds <div atk-paginator> itself inside <?$paginator?> spot.
