### PR TITLE
Fixes for Grid panel

### DIFF
--- a/lib/Grid/Advanced.php
+++ b/lib/Grid/Advanced.php
@@ -19,9 +19,7 @@ class Grid_Advanced extends Grid_Basic {
     public $last_column;
     public $sortby='0';
     public $sortby_db=null;
-    public $not_found=false;
-
-    public $displayed_rows=0;
+    public $buttonset=null;
 
     private $totals_title_field=null;
     private $totals_title="";
@@ -105,8 +103,10 @@ class Grid_Advanced extends Grid_Basic {
         return $this;
     }
     function addButton($label){
-        return $this
-            ->add('Button','gbtn'.count($this->elements),'grid_buttons')
+        if(!$this->buttonset)
+            $this->buttonset=$this->add('ButtonSet',null,'grid_buttons');
+        return $this->buttonset
+            ->add('Button','gbtn'.count($this->elements))
             ->setLabel($label);
     }
     function addQuickSearch($fields,$class='QuickSearch'){

--- a/lib/QuickSearch.php
+++ b/lib/QuickSearch.php
@@ -26,27 +26,19 @@ class QuickSearch extends Filter {
     /*
      * Quicksearch represents one-field filter which goes perfectly with a grid
      */
-
-    public $js_widget='ui.atk4_form';
-    public $icon;// to configure icon
-    var $region=null;
-    var $region_url=null;
-    public $search_cross=null;
-    public $grid;
+    public $icon='search'; // to configure icon
 
     function init(){
         parent::init();
-        //$this->addClass('span3');
 
-        $this->addClass('float-right stacked span4');
+        $this->addClass('float-right span4 atk-quicksearch');
         $this->template->trySet('fieldset','atk-row');
         $this->template->tryDel('button_row');
         $this->search_field=$this->addField('line','q','')->setNoSave();
         $this->search_field->addButton('')
             ->setHtml('&nbsp;')
-            ->setIcon('search')
+            ->setIcon($this->icon)
             ->js('click',$this->js()->submit());
-            ;
     }
     function useFields($fields){
         $this->fields=$fields;

--- a/templates/shared/css/atk-main.css
+++ b/templates/shared/css/atk-main.css
@@ -981,7 +981,13 @@ textarea:focus {
   clear: both;
 }
 .atk-grid > .atk-grid-panel {
-  margin: 0 0 0.6666666666666666em 0;
+  float: left;
+}
+.atk-grid > .atk-grid-panel > .ui-buttonset {
+  margin: 0.1666666666666666em 0 0.5em 0;
+}
+.atk-grid > .atk-grid-panel > .atk-quicksearch {
+  margin: 0.1666666666666666em 0 0.5em 0;
 }
 .atk-grid > table {
   border-collapse: separate;

--- a/templates/shared/css/atk-main.less
+++ b/templates/shared/css/atk-main.less
@@ -595,7 +595,10 @@ textarea:focus {
 .atk-wrapper {.fixed-container();}
 
 .atk-grid {
-	>.atk-grid-panel { margin:0 0 @margin/3 0; }
+	>.atk-grid-panel {
+        float:left;
+        >.ui-buttonset,>.atk-quicksearch {margin:@margin/12 0 @margin/4 0;}
+    }
 	>table {
 		border-collapse:separate;
 		width:100%;

--- a/templates/shared/grid.html
+++ b/templates/shared/grid.html
@@ -1,9 +1,6 @@
 <?$Misc?>
 <div id="<?$_name?>" class="atk-grid <?$class?>">
-  <div class="atk-grid-panel">
-    <?quick_search?><?/?>
-    <div class="atk-buttons"><?grid_buttons?>&nbsp;<?/?></div>
-  </div>
+  <div class="atk-grid-panel"><?$quick_search?><?$grid_buttons?></div>
   <table width="<?table_width?>100%<?/?>">
     <?header?>
     <thead class="ui-widget-header"><tr>
@@ -37,8 +34,6 @@
       </tr>
       <?/totals?>
       <?/rows?>
-
-
     </tbody>
     <?$full_table?>
   </table>


### PR DESCRIPTION
**Issue:**
Even if no buttons and no quick-search form is added to grid, it still show empty grid-panel block.

**Solution included:**
1. Organize grid buttons (in grid-panel) in buttonset. That have 2 bonuses. First, it's easier to add CSS styles to them, and second - it looks nicer when you have more than 1 button in top panel.
2. Slight changes in quicksearch form CSS. In fact, introduced new css class atk-quicksearch too. That will also help developers to define their CSS of quicksearch block.
3. Removed margins from grid-panel (because if it's empty, then it should not be visible) and moved these margins to buttonset and quicksearch block. So, they will be effective only if one of above will be enabled / used.
4. Also removed some not used variables.
