### PR TITLE
nl2br for readonly textarea form field

### DIFF
--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -476,11 +476,7 @@ class Form_Field_Readonly extends Form_Field {
     }
 
     function getInput($attr=array()){
-        if (isset($this->value_list)){
-            return $this->value_list[$this->value];
-        } else {
-            return $this->value;
-        }
+        return nl2br(isset($this->value_list) ? $this->value_list[$this->value] : $this->value);
     }
     function setValueList($list){
         $this->value_list = $list;


### PR DESCRIPTION
Added nl2br for displaying value of readonly fields.
It's needed if you want to display <textarea> field as readonly.
In other situations (other fields) nl2br will not do any bad too.
