### PR TITLE
Fix includeCSS() for IE to work correctly

### DIFF
--- a/templates/js/start-atk4.js
+++ b/templates/js/start-atk4.js
@@ -336,13 +336,17 @@ $.extend($.atk4,{
 	 Also relative URLs like url(../images) will not break.
 	*/
     includeCSS: function(url){
-		if(this._isIncluded(url))return;
+        if(this._isIncluded(url))return;
 
-		$("<link>", {
-			rel: "stylesheet",
-			type: "text/css",
-			href: url
-		}).appendTo("head");
+        /*
+         Dynamically loads CSS. Now works for IE too as noted in:
+         http://stackoverflow.com/questions/1184950/dynamically-loading-css-stylesheet-doesnt-work-on-ie
+         see comment by ekerner on Apr 4 11 at 16:44
+        */
+        $("<link>")
+            .appendTo($('head'))
+            .attr({type : 'text/css', rel : 'stylesheet'})
+            .attr('href', url);
     },
     _isIncluded: function(url){
         if(this._includes[url])return true;


### PR DESCRIPTION
I found solution here:
http://stackoverflow.com/questions/1184950/dynamically-loading-css-stylesheet-doesnt-work-on-ie
comment by ekerner on Apr 4 11 at 16:44.

Tested that on my IE8 and it really works !!!
Stupid IE :-1:
