### PR TITLE
data-shortname attribute for dropdown

### DIFF
--- a/lib/Form/Field/DropDown.php
+++ b/lib/Form/Field/DropDown.php
@@ -18,6 +18,7 @@ class Form_Field_DropDown extends Form_Field_ValueList {
     function getInput($attr=array()){
         $output=$this->getTag('select',array_merge(array(
                         'name'=>$this->name,
+			'data-shortname'=>$this->short_name,
                         'id'=>$this->name,
                         ),
                     $attr,


### PR DESCRIPTION
i think it was just deleted accidentally. Because it worked before

This attribute is used to show field error
