### PR TITLE
Fixed form field reload for shortened cases

### DIFF
--- a/templates/js/ui.atk4_form.js
+++ b/templates/js/ui.atk4_form.js
@@ -183,7 +183,7 @@ jQuery.widget("ui.atk4_form", {
 		f.val(value).change();
 	},
 	reloadField: function(field_name,url,fn,notrigger,arg){
-		var field_id=this.id+'_'+field_name;
+		var field_id = $("#"+this.id+' input[data-shortname="'+field_name+'"]').first().attr("id");
 		if(!url)url=this.base_url;
 		console.log('Field reloading: ',field_name);
         if(arg){
@@ -193,6 +193,7 @@ jQuery.widget("ui.atk4_form", {
         }
 		url=$.atk4.addArgument(url,this.id+'_cut_field',field_id);
 		var f=$("#"+field_id);
+		console.log('Field found: ',field_id,'->',f);
 
 		if(!notrigger)f.trigger('reload_field');
 


### PR DESCRIPTION
When the id is shortened on php side the field reload was calculating the wrong id

test case to include in testsuite:

```
<?php
//Don't name the class too long or even the first field will be shortened!
class page_test extends Page {
    function init() {
        parent::init();

        $div = $this->add("View","container");

        $form = $div->add("Form");

        $nc = $form->addField("line", "short");
        $nc->set(rand());   
        $nl = $form->addField("line",       "really_long_name_that_will_be_shortened_for_sure_on_the_sixty_char");
        $nl->set(rand());   
        $b = $this->add("Button")
            ->set('Click should refresh both field')
            ->js('click',array(
                $form->js()->atk4_form('reloadField', "short"),
$form->js()->atk4_form('reloadField',"really_long_name_that_will_be_shortened_for_sure_on_the_sixty_char")
            ));

    }
}
```
