### PR TITLE
getCount(): new "shortcut" method in Model_Table

### DIFF
--- a/lib/Model/Table.php
+++ b/lib/Model/Table.php
@@ -401,6 +401,10 @@ class Model_Table extends Model {
         $q = $this->dsql();
         return $q->fieldQuery($q->count());
     }
+    /** Returns count of records */
+    function getCount(){
+       return $this->count()->getOne();
+    }
     /** Returns dynamic query selecting sum of particular field */
     function sum($field){
         if(!is_object($field))$field=$this->getElement($field);


### PR DESCRIPTION
I realizes I use $model->count()->getOne() in most of my pages, so I guess there should be shortcut method for this.
You can use it simply like this: $model->getCount().
