### PR TITLE
Fix Controller_Data_Session

### DIFF
--- a/lib/Controller/Data/Session.php
+++ b/lib/Controller/Data/Session.php
@@ -28,7 +28,9 @@ class Controller_Data_Session extends Controller_Data_Array {
         if(!$_SESSION['ctl_data'][$data]){
             $_SESSION['ctl_data'][$data]=array();
         }
-
+        if(!$_SESSION['ctl_data'][$data][$model->table]){
+            $_SESSION['ctl_data'][$data][$model->table]=array();
+        }
 
         $model->_table[$this->short_name] =& $_SESSION['ctl_data'][$data][$model->table];
     }


### PR DESCRIPTION
if no data in session, then iterators throw errors if we don't initialize "table" as empty array.
