### PR TITLE
Form_Basic: fix last_field, remove disable()

### DIFF
--- a/lib/Form/Basic.php
+++ b/lib/Form/Basic.php
@@ -165,18 +165,12 @@ class Form_Basic extends View {
         $last_field->template->trySet('field_type',strtolower($type));
         if (is_array($attr)){
             foreach ($attr as $key => $value){
-                $this->last_field->setProperty($key, $value);
+                $last_field->setProperty($key, $value);
             }
         }
 
         return $last_field;
     }
-    function disable(){
-        // disables last field
-        $this->last_field->disable();
-        return $this;
-    }
-
     function importFields($model,$fields=undefined){
         $this->add('Controller_MVCForm')->importFields($model,$fields);
     }


### PR DESCRIPTION
1. $form->last_field is no more used anywhere and incorrectly used with setting attributes trough addField() method.
2. $form->disable() tried to disable last added field, but ... it's not used anywhere. As result this is useless method. We can disable field by using $field->disable().
3. Maybe there should be method $form->disable(), but with completely different meaning - disable all form fields one by one. I'm not sure could it be useful or not.
