### PR TITLE
FormBasic: addSeparator fix

### DIFF
--- a/lib/Form/Basic.php
+++ b/lib/Form/Basic.php
@@ -182,7 +182,7 @@ class Form_Basic extends View {
     }
     function addSeparator($class='',$attr=array()){
         if(!isset($this->template_chunks['form_separator']))return $this;
-        $c=$this->template_chunks['form_separator'];
+        $c = clone $this->template_chunks['form_separator'];
         $c->trySet('fieldset_class',$class);
         
         if(is_array($attr) && !empty($attr))


### PR DESCRIPTION
Need to clone template otherwise source template_chunk changes on each call of addSeparator()
