### PR TITLE
Field_ValueList: fix loadPOST

### DIFF
--- a/lib/Form/Field/ValueList.php
+++ b/lib/Form/Field/ValueList.php
@@ -80,6 +80,7 @@ class Form_Field_ValueList extends Form_Field {
         if(isset($_POST[$this->name])){
             $data=$_POST[$this->name];
             if(is_array($data))$data=implode(',',$data);
+            $data = trim($data,',');
             
             if (get_magic_quotes_gpc()){
                 $this->set(stripslashes($data));


### PR DESCRIPTION
When passing values + also checked Empty Text checkbox,
then received string was like this 'A,B,C,' (ending with comma).
We better remove this not needed comma. Used trim and not rtrim
to be even more sure that commas will be removed.
