### PR TITLE
View_CRUD: fix for addRef()

### DIFF
--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -291,7 +291,9 @@ class View_CRUD extends View
             throw $this->exception('Must be array');
         }
 
-        if ($this->isEditing('ex_'.$name)) {
+        $s = $this->api->normalizeName($name);
+        
+        if ($this->isEditing('ex_'.$s)) {
 
             if ($_GET['id']) {
                 $this->id = $_GET[$this->name.'_id'] = $_GET['id'];
@@ -319,9 +321,9 @@ class View_CRUD extends View
             return;
         }
 
-        $this->grid->addColumn('expander', 'ex_'.$name, $options['label']?:$name);
-        $this->grid->columns['ex_'.$name]['page']
-            = $this->virtual_page->getURL('ex_'.$name);
+        $this->grid->addColumn('expander', 'ex_'.$s, $options['label']?:$s);
+        $this->grid->columns['ex_'.$s]['page']
+            = $this->virtual_page->getURL('ex_'.$s);
     }
 
     /**


### PR DESCRIPTION
Now you can also use advanced element names in addRef.
For example, $crud->addRef('vendor\addon\Class') or $crud->addRef(**NAMESPACE** . '/Class');

Fix for: https://github.com/atk4/atk4/issues/260
