### PR TITLE
Form_Basic: name fix in addField()

### DIFF
--- a/lib/Form/Basic.php
+++ b/lib/Form/Basic.php
@@ -167,7 +167,7 @@ class Form_Basic extends View implements ArrayAccess {
             case 'checkbox':     $class = 'Checkbox';     break;
             case 'password':     $class = 'Password';     break;
             case 'timepickr':    $class = 'TimePicker';   break;
-            default:            $class = $type;
+            default:             $class = $type;
         }
         $class = $this->api->normalizeClassName($class, 'Form_Field');
         $last_field = $this->add($class, $name, null, 'form_line')


### PR DESCRIPTION
If you call ->addField('dropdown','Is admin?'), then it created HTML elements with name='...Is admin?' which is not correct name.
It should be normalized before using it as part of HTML element name.
https://groups.google.com/forum/?fromgroups=#!topic/agile-toolkit-devel/5a979QuH-vA
