### PR TITLE
custom page in router url

### DIFF
--- a/lib/Controller/PatternRouter.php
+++ b/lib/Controller/PatternRouter.php
@@ -30,25 +30,25 @@ class Controller_PatternRouter extends AbstractController {
 
     function buildURL($junk,$url){
         if ($this->links[$url->page]) {
+            $base_url = $url->page;
             // start consuming arguments
-
             $args=$this->links[$url->page];
-            $count = 0;
-            foreach ($args as $key=>$match) {
 
-                if ($count == 0 && $key == 'page') {
-                    $url->page = $match;
-                }
+            foreach ($args as $key=>$match) {
 
                 if(is_numeric($key)){
                     $key=$match;
                 }
 
                 if (isset($url->arguments[$key])) {
-                    $url->page.='/'.$url->arguments[$key];
+                    if ($key == 'base_page') {
+                        $url->page = str_replace($base_url,$url->arguments[$key],$url->page);
+                    } else {
+                        $url->page.='/'.$url->arguments[$key];
+                    }
                     unset($url->arguments[$key]);
                 }
-                $count++;
+
             }
         }
     }


### PR DESCRIPTION
Second try with code fixes and explanations :)

Lets say we have page cat/list, and we want this page to appear 
under URL different from cat/list. And URL what we want to see compiled 
from non static words. We use some variables to create this URL. 
One var is $category. So url must look like this:

```
/:category
```

We need to use Controller_PatternRouter to implement this.
Lets say we have list of categories in var $category_list_array

```
Frontend.php

$this->add('Controller_PatternRouter');
foreach ($category_list_array as $k=>$v) {
    $this->router->addRule('('.$k.')','cat_list',array('category_trans'));
}
```

Everything will work fine from this point on.
We will show articles from different categories depending on var $_GET['category_trans'].
Lets say we have Grid with Paginator on page cat/list. What URL's will be generated for 
this Paginator to navigate through pages?

```
/cat/list?id_of_paginator_skip=XXX
```

And here we have a trouble because $_GET['category_trans'] has been lost, 
and Grid will show wrong results after first click on Paginator buttons.
Of course we can add something like $this->api->stickyGet('category_trans'), 
but this looks not elegant. And second approach is using 
method Controller_PatternRouter::link($page, $args=array()). Just add rules in Frontend.php

```
foreach ($category_list_array as $k=>$v) {
    $this->router->link($k,array('category_trans'));
}
```

But this solution will not work in our case because Paginator will use 
real Page (cat/list) for creating URL's, and there is no way to tell him to change 
this base page.

My improvement is about giving the way to say router to change base page in url. 
Just pass 'base_page' parameter to ->api->url(). Like this

```
$this->api->url('cat/list',array(
    'base_page'=>'category_name',
));
```

As a result we will see URL like this:

```
/category_name
```
