### PR TITLE
QuickSearch: show cancel button by default

### DIFF
--- a/lib/QuickSearch.php
+++ b/lib/QuickSearch.php
@@ -32,7 +32,7 @@ class QuickSearch extends Filter
     protected $bset;
     
     // cancel button
-    public $show_cancel = false; // show cancel button? (true|false)
+    public $show_cancel = true; // show cancel button? (true|false)
 
     /**
      * Initialization


### PR DESCRIPTION
I believe we should show cancel button by default. It's useful most of the time. Do you agree?
