### PR TITLE
MVCGrid: type_associations fix

### DIFF
--- a/lib/Controller/MVCGrid.php
+++ b/lib/Controller/MVCGrid.php
@@ -39,12 +39,12 @@ class Controller_MVCGrid extends AbstractController {
         'datetime'=>'timestamp',
         'date'=>'date',
         'daytime'=>'daytime',
-        'daytime_total'=>'daytime_total',
         'boolean'=>'boolean',
         'list'=>'text',
+        'radio'=>'text',
         'readonly'=>'text',
         'image'=>'text',
-        'file'=>'referenece',
+        'file'=>'reference',
         'password'=>'password',
     );
 


### PR DESCRIPTION
1) added type 'radio' because it's in MVCForm too
2) removed type 'daytime_total' because it's not used anywhere
