### PR TITLE
bindConditionalShow: fix for shortened fieldnames

### DIFF
--- a/templates/js/atk4_univ.js
+++ b/templates/js/atk4_univ.js
@@ -524,7 +524,8 @@ bindConditionalShow: function(conditions,tag){
 		var s=[];
 		fid=n;
 		$.each(name,function(){
-			var dom=(this[0]=='#'?$(this+'')[0]:$(a='#'+fid+'_'+this)[0]);
+			var a = (this[0]=='#'?this+'':"[data-shortname='"+this+"']");
+			var dom = $(a, '#'+fid)[0];
 			if(dom){
 				s.push(dom);
 			}else{


### PR DESCRIPTION
If you had not shortened form name and shortened field name, then bindConditionalShow didn't work because it used form ID to generate field ID.
Some time ago data-shortname attribute for fields was introduced and now bindConditionalShow also uses this attribute to correctly find respective fields no matter if they have shortened field names or not.
