### PR TITLE
Model->set(): fix for array controller

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -135,6 +135,7 @@ class Model extends AbstractModel implements ArrayAccess,Iterator,Serializable {
                 || is_array($this->data[$name])
                 || (string)$value!=(string)$this->data[$name] // this is not nice.. 
                 || $value !== $this->data[$name] // considers case where value = false and data[$name] = null
+                || !isset($this->data[$name]) // considers case where data[$name] is not initialized at all (for example in model using array controller)
             )
         ) {
             $this->data[$name]=$value;


### PR DESCRIPTION
If we use array controller for model where data source is array, then inserting NULL values for fields don't create appropriate array key.
That's because $value === $this->data[$name] if $this->data[$name] silently fails and as result is cast to NULL too. So NULL === NULL and field value equal NULL is not set (and as result - not saved).
