### PR TITLE
RestAPI: add abstract methods

### DIFF
--- a/lib/Controller/Data/RestAPI.php
+++ b/lib/Controller/Data/RestAPI.php
@@ -44,4 +44,18 @@ class Controller_Data_RestAPI extends Controller_Data {
         curl_close($ch);
         return json_decode($result);
     }
+
+    /* Methods below are not implemented !!! */
+    function load($model,$id){throw $this->exception('Method not implemented!');}
+    function save($model){throw $this->exception('Method not implemented!');}
+    function delete($model,$id){throw $this->exception('Method not implemented!');}
+    function tryLoad($model,$id){throw $this->exception('Method not implemented!');}
+    function loadBy($model,$field,$cond,$value){throw $this->exception('Method not implemented!');}
+    function tryLoadBy($model,$field,$cond,$value){throw $this->exception('Method not implemented!');}
+    function tryLoadAny($model){throw $this->exception('Method not implemented!');}
+    function deleteAll($model){throw $this->exception('Method not implemented!');}
+    function getRows($model){throw $this->exception('Method not implemented!');}
+    function getBy($model,$field,$cond,$value){throw $this->exception('Method not implemented!');}
+    function rewind($model){throw $this->exception('Method not implemented!');}
+    function next($model){throw $this->exception('Method not implemented!');}
 }


### PR DESCRIPTION
These are not implemented, but because they are defined in abstract parent class Controller_Data as abstract methods they need to be present here. For now just throw exceptions.
