### PR TITLE
Form AJAX submit: loader, disable fields and more

### DIFF
--- a/lib/Form/Basic.php
+++ b/lib/Form/Basic.php
@@ -148,7 +148,9 @@ class Form_Basic extends View implements ArrayAccess {
             $this->js()->univ()->alert($msg?:'Error in form')->execute();
         }
         if(!is_object($field))$field=$this->getElement($field);
-        $this->js()->atk4_form('fieldError',$field->short_name,$msg)->execute();
+
+        $fn = $this->js_widget ? str_replace('ui.', '', $this->js_widget) : 'atk4_form';
+        $this->js()->$fn('fieldError',$field->short_name,$msg)->execute();
     }
     function addField($type, $options, $caption=null, $attr=null)
     {

--- a/templates/js/ui.atk4_form.js
+++ b/templates/js/ui.atk4_form.js
@@ -27,6 +27,7 @@ jQuery.widget("ui.atk4_form", {
 	submitted: undefined,
 	base_url: undefined,
 	loading: false,
+	show_loader: true,      // show loader indicator on ajax submit?
 	plain_submit: false,
 
 	template: {},
@@ -299,9 +300,9 @@ jQuery.widget("ui.atk4_form", {
 		}
 
 		// btn is clicked
-		var richtext=this.element.find('.atk4_richtext');
+		var richtext=form.element.find('.atk4_richtext');
 		if(richtext.length)richtext.atk4_richtext('changeHTML');
-		params=this.element.find(":input").serializeArray()
+		params=form.element.find(":input").serializeArray();
 		if(btn){
             for (var el in params){
                 if (params[el].name == 'ajax_submit'){
@@ -313,12 +314,23 @@ jQuery.widget("ui.atk4_form", {
 
 		var properties={
 			type: "POST",
-			url: this.form.attr('action')
+			url: form.form.attr('action')
 		};
 
 		form.loading=true;
+        if(form.show_loader){
+            form.element.atk4_loader().atk4_loader('showLoader');
+        }
+        
+        // disable all fields and buttons while submitting
+        form.element.find(":input:enabled")
+            .attr("disabled",true)
+            .attr("reenable",true);
+		
+		// do request
 		$.atk4.get(properties,params,function(res){
-			var c=form._getChanged();form._setChanged(false);
+			var c=form._getChanged();
+			form._setChanged(false);
 
 			if(!$.atk4._checkSession(res))return;
 			/*
@@ -333,17 +345,24 @@ jQuery.widget("ui.atk4_form", {
 				//while some browsers prevents popup we better use alert
 				w=window.open(null,null,'height=400,width=700,location=no,menubar=no,scrollbars=yes,status=no,titlebar=no,toolbar=no');
 				if(w){
-					w.document.write('<h2>Error in AJAX response: '+e+'</h2>');
+					w.document.write('<h5>Error in AJAX response: '+e+'</h5>');
 					w.document.write(res);
 					w.document.write('<center><input type=button onclick="window.close()" value="Close"></center>');
 				}else{
 					alert("Error in AJAX response: "+e+"\n"+res);
 				}
 			}
-			form.loading=false;
 			form._setChanged(c);
 		},function(){
 			form.loading=false;
+            if(form.show_loader){
+                form.element.atk4_loader().atk4_loader('hideLoader');
+            }
+
+            // reenable all fields and buttons which was previously enabled
+            form.element.find(":input[reenable]")
+                .removeAttr("disabled")
+                .removeAttr("reenable");
 		});
 	}
 });

--- a/templates/js/ui.atk4_loader.js
+++ b/templates/js/ui.atk4_loader.js
@@ -25,13 +25,9 @@
    .atk4_loader({url: '/page.html'})
    .atk4_loader({})
 
-
  THE STRUCTURE OF THIS WIDGET MIGHT BE REWRITTEN
 
-
 */
-
-
 
 $.widget('ui.atk4_loader', {
 
@@ -61,6 +57,13 @@ $.widget('ui.atk4_loader', {
     */
     helper: undefined,
     loader: undefined,
+    
+    showLoader: function(){
+        if(!!this.loader) this.loader.show();
+    },
+    hideLoader: function(){
+        if(!!this.loader) this.loader.hide();
+    },
 
 	_create: function(){
 
@@ -82,8 +85,8 @@ $.widget('ui.atk4_loader', {
         if(this.options.cogs){
             var l=$(this.options.cogs);
 			l.prependTo(self.element);
-            l.hide();
             self.loader=l;
+            self.hideLoader();
         }
 
         if(this.options.history){
@@ -127,11 +130,7 @@ $.widget('ui.atk4_loader', {
 	},
 	destroy: function(){
 		var self=this;
-		/*
-		if(self.parent_loader){
-			self.parent_loader.unbind('atk4_loaderbeforeclose.'+self.element.attr('id'));
-		}
-		*/
+
 		this.element.removeClass('atk4_loader');
 		if(this.helper){
 			this.helper.remove();
@@ -172,7 +171,7 @@ $.widget('ui.atk4_loader', {
 		var m;
 
 		self.loading=true;
-        self.loader.show();
+        self.showLoader();
         $.atk4.get(url,null,function(res){
 			/*
 			if(res.substr(0,13)=='SESSION OVER:'){
@@ -184,7 +183,6 @@ $.widget('ui.atk4_loader', {
             if(self.options.history)window.history.pushState({path: self.base_url}, 'foobar', self.base_url);
 
             var scripts=[], source=res;
-
 
             while((s=source.indexOf("<script"))>=0){
                 s2=source.indexOf(">",s);
@@ -226,7 +224,6 @@ $.widget('ui.atk4_loader', {
 				});
 			}
 
-
 			el.atk4_loader({'base_url':url});
 
 			/*
@@ -250,11 +247,9 @@ $.widget('ui.atk4_loader', {
                 if(!f.hasClass('nofocus'))f.focus();
 			});
 		},function(){	// second callback, which is always called, when loading is completed
-            if (!!self.loader){
-                self.loader.hide();
-            }
+            self.hideLoader();
 			self.loading=false;
-            		el.trigger('after_html_loaded');
+            el.trigger('after_html_loaded');
 		});
     },
 	/*
@@ -325,7 +320,7 @@ $.extend($.ui.atk4_loader, {
 
 $.fn.extend({
 	atk4_load: function(url,fn){
-        this.atk4_loader().atk4_loader('loadURL',url,fn) ;
+        this.atk4_loader().atk4_loader('loadURL',url,fn);
 	},
 	atk4_reload: function(url,arg,fn){
         if(arg){
@@ -334,7 +329,6 @@ $.fn.extend({
             });
         }
 		this.atk4_loader()
-			.atk4_loader('loadURL',url,fn,true)
-			;
+			.atk4_loader('loadURL',url,fn,true);
 	}
 });


### PR DESCRIPTION
**Features:**
1) loader show/hide functions in atk4_loader for more general usage
2) show loading indicator on ajax submit of form (uses atk4_loader show/hide functions)
3) disable all input elements (fields, buttons) of form while doing ajax submit
4) reenable fields (only these which was previously enabled) after ajax submit finished

**Fixes:**
1) correctly use $js_widget in Form class
