### PR TITLE
PathFinder: fix

### DIFF
--- a/lib/PathFinder.php
+++ b/lib/PathFinder.php
@@ -503,6 +503,11 @@ class PathFinder_Location extends AbstractModel {
         // Vendor\MyAddon otherwise these are not found on *Nix systems
         $filename = str_replace('\\','/',$filename);
 
+        // Imants: remove query parameters if any
+        if (($p = strpos($filename, '?')) !== false) {
+            $filename = substr($filename, 0, $p);
+        }
+
         $attempted_locations=array();
         $locations=array();
         $location=null;


### PR DESCRIPTION
Sometimes we search for files which have URL query parameters. In this case we should try to locate base file name (without query parameters).
For example, if we try to locate template "foo.css?v=666" then actually we should try to locate file foo.css not foo.css?v=666
