### PR TITLE
jUITabs: fixes and upgrades

### DIFF
--- a/lib/View/Tabs/jUItabs.php
+++ b/lib/View/Tabs/jUItabs.php
@@ -28,19 +28,30 @@
 **/
 class View_Tabs_jUItabs extends View_Tabs {
     public $tab_template=null;
-    public $options=array('cache'=>false);
+    public $options=array();
+
+    // should we show loader indicator while loading tabs
+    public $show_loader = true;
 
     function init(){
         parent::init();
         $this->tab_template=$this->template->cloneRegion('tabs');
         $this->template->del('tabs');
     }
-    /* Set tabs option, for example, 'selected'=>'zero-based index of tab */
+    /* Set tabs option, for example, 'active'=>'zero-based index of tab */
     function setOption($key,$value){
         $this->options[$key]=$value;
         return $this;
     }
     function render(){
+        // add loader to JS events
+        if ($this->show_loader) {
+            $this->options['beforeLoad'] = $this->js()->_enclose()->_selectorThis()
+                ->atk4_loader()->atk4_loader('showLoader');
+            $this->options['load'] = $this->js()->_enclose()->_selectorThis()
+                ->atk4_loader()->atk4_loader('hideLoader');
+        }
+        // render JUI tabs
         $this->js(true)
             ->tabs($this->options);
 


### PR DESCRIPTION
1. fix: fixed example in comment selected --> active
2. fix: remove unused option 'cache'. This was left from old times when we used atk4 own js Tab library.
3. upgrade: now loader indicator (gears) will show while loading content of tab. Can be switched off by setting $this->show_loader = false;
