### PR TITLE
View_DropButton: fixes

### DIFF
--- a/lib/View/DropButton.php
+++ b/lib/View/DropButton.php
@@ -16,23 +16,21 @@
  =====================================================ATK4=*/
 class View_DropButton extends Button {
 
-    public $menu=null;
+    public $menu = null;
 
     function render(){
         if(!isset($this->options['icons']['secondary'])){
-            $this->options['icons']['secondary']='ui-icon-triangle-1-s';
+            $this->options['icons']['secondary'] = 'ui-icon-triangle-1-s';
         }
         parent::render();
     }
     /* Show menu when clicked */
-    function useMenu($width=3){
-        $flyout=$this->owner->add('View_Popover',null,$this->spot);
-        $flyout->useArrow();
+    function useMenu(){
+        $popover = $this->owner->add('View_Popover', null, $this->spot);
 
-        $this->menu=$flyout->add('Menu_jUI');
+        $this->menu = $popover->add('Menu_jUI');
 
-        $this->js('click',$flyout->showJS($this));
-
+        $this->js('click', $popover->showJS($this));
 
         return $this->menu;
     }


### PR DESCRIPTION
Fix DropButton. Some issues showed up when you upgraded this to use View_Popover instead of Flyout. Now it works nicely.

Example usage:
$this->add('View_DropButton', null, 'User_Menu')
  ->setHTML('<strong>Welcome</strong>, '.$this->auth->model['name'])
  ->useMenu()
    ->addMenuItem('#',      'Messages')
    ->addMenuItem('#',      'Settings')
    ->addMenuItem('logout', 'Sign Out')
  ;
