### PR TITLE
MVCForm: upgrade support of form field placeholders

### DIFF
--- a/lib/Controller/MVCForm.php
+++ b/lib/Controller/MVCForm.php
@@ -108,8 +108,9 @@ class Controller_MVCForm extends AbstractController {
         $form_field = $this->owner->addField($field_type,$field_name,$field_caption);
         $form_field->set($field->get());
 
-        if($field->placeholder()){
-            $form_field->setAttr('placeholder',$field->placeholder());
+        $field_placeholder = $field->placeholder() ?: $field->emptyText() ?: null;
+        if ($field_placeholder) {
+            $form_field->setAttr('placeholder', $field_placeholder);
         }
 
         if($field->hint()){


### PR DESCRIPTION
Now emptyText of model work as placeholder too as it was meant to.
I found out that in following comment in model Field class on line 410 for method emptyText:

```
* if you are using this setting with a text field it will set a
* placeholder HTML property.
```
