### PR TITLE
Grid_Advanced: formatTotalsRow fix

### DIFF
--- a/lib/Grid/Advanced.php
+++ b/lib/Grid/Advanced.php
@@ -403,12 +403,15 @@ class Grid_Advanced extends Grid_Basic
         parent::formatTotalsRow();
 
         // additional formatting of totals row
+        $totals_columns = array_keys($this->totals) ?: array();
         foreach ($this->columns as $field=>$column) {
 
-            // process formatters
-            $this->executeFormatters($field, $column, 'format_totals_');
+            // process formatters only for columns included in totals calculation
+            if (in_array($field, $totals_columns)) {
+                $this->executeFormatters($field, $column, 'format_totals_');
+            }
 
-            // apply TD parameters
+            // apply TD parameters to all columns
             $this->applyTDParams($field, $this->totals_t);
         }
 


### PR DESCRIPTION
formatTotalsRow now will only use formatters (format_total_*) for columns on which we actually do totals calculations.
TD params are still applied to all columns because mostly is align=left|right there and that doesn't do anything bad.
