### PR TITLE
throw consistently all errors into exceptions

### DIFF
--- a/lib/static.php
+++ b/lib/static.php
@@ -56,10 +56,8 @@ if(!function_exists('error_handler')){
                 case 8192:
                     if(substr($errstr,-13)=='is deprecated')break;
                 default:
-                    if(ini_get('display_errors') == 1 || ini_get('display_errors') == 'ON')
-                        echo "$str<br />\n";
-                    if(ini_get('log_errors') == 1 || ini_get('log_errors') == 'ON')
-                        error_log(" $errfile:$errline\n[".$errorType[$errno]."] ".strip_tags($errstr),0);
+                    // throw consistently all errors into exceptions
+                    throw new ErrorException($errorType[$errno].': ['.$errfile.':'.$errline.']'. $errstr, 0, $errno, $errfile, $errline);
                     break;
             }
         }


### PR DESCRIPTION
Atk4 shows a nice message by default when an error exception occurs which are handled by the Logger class. However some errors are not reported as exception by php and then atk4 will handle this in static.php.
E.g. ftp_login($this->connection, $this->user, $this->pass) will generate this error by static.php:
/lib/FTP.php:60 [2] ftp_login() [function.ftp-login]: Login incorrect.

This pull request will also passthrough these errors as exceptions. This way it also reaches the Logger class and handles it conform how Logger is configured ( $config['logger'] options).
