### PR TITLE
MVCForm: we don't need "Please select" option for mandatory fields

### DIFF
--- a/lib/Controller/MVCForm.php
+++ b/lib/Controller/MVCForm.php
@@ -131,7 +131,7 @@ class Controller_MVCForm extends AbstractController {
         if($field->theModel){
             $form_field->setModel($field->theModel);
         }
-        if($form_field instanceof Form_Field_ValueList) {
+        if($form_field instanceof Form_Field_ValueList && !$field->mandatory()) {
             $form_field->setEmptyText($field->emptyText());
         }
 


### PR DESCRIPTION
I guess we don't need "Please select" option in Radio or Dropdown form fields if related model field is mandatory.
Otherwise it looks quite strange that there is such option in form at all which will not be accepted anyway.
