### PR TITLE
Model->set(), fix for "dirty" comparison

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -127,15 +127,20 @@ class Model extends AbstractModel implements ArrayAccess,Iterator,Serializable {
         if($this->strict_fields && !$this->hasElement($name))throw $this->exception('No such field','Logic')
             ->addMoreInfo('name',$name);
 
-        if($value!==undefined 
+        if ($value !== undefined 
             && (
-                is_object($value) 
+                // if data[$name] is not initialized at all (for example, in model using array controller)
+                !isset($this->data[$name])
+                // value as object
+                || is_object($value)
                 || is_object($this->data[$name])
+                // value as array
                 || is_array($value)
                 || is_array($this->data[$name])
-                || (string)$value!=(string)$this->data[$name] // this is not nice.. 
-                || $value !== $this->data[$name] // considers case where value = false and data[$name] = null
-                || !isset($this->data[$name]) // considers case where data[$name] is not initialized at all (for example in model using array controller)
+                // if one and only one value is NULL
+                || (is_null($value) xor is_null($this->data[$name]))
+                // values converted to string loosly differ
+                || (string)$value != (string)$this->data[$name] // this is not nice
             )
         ) {
             $this->data[$name]=$value;


### PR DESCRIPTION
I hope this way it'll work better, because old
(string)$value!==(string)$this->data[$name] don't work well for boolean value fields.
For example, (string)"1" !== (string)1 or (string)true will return true and as result set field as dirty.
We should use loose comparison != here instead, but at the same time take care of NULL values, because these need special treatment (as always) :P
