### PR TITLE
grid template: take care of floats

### DIFF
--- a/templates/shared/grid.html
+++ b/templates/shared/grid.html
@@ -2,7 +2,7 @@
 <div id="<?$_name?>" class="atk-grid <?$class?>" style="<?$style?>" <?$attributes?>>
   
   <?$top_1?>
-  <div class="atk-grid-panel"><?$quick_search?><?$grid_buttons?></div>
+  <div class="atk-grid-panel clearfix"><?$quick_search?><?$grid_buttons?></div>
   <?$top_2?>
   
   <?all_table?>
@@ -50,7 +50,7 @@
   </table>
   <?/?>
   <?not_found?>
-    <div class="atk-grid-notfound ui-state-highlight ui-corner-all"><i class="ui-icon ui-icon-alert float-left"></i><?not_found_message?>No Records Found<?/?></div>
+    <div class="atk-grid-notfound ui-state-highlight ui-corner-all clearfix"><i class="ui-icon ui-icon-alert float-left"></i><?not_found_message?>No Records Found<?/?></div>
   <?/not_found?>
 
   <?$bottom_1?>


### PR DESCRIPTION
where there is no records in grid and no buttons, but have right floated quicksearch, then notfound message should clear floats otherwise it is shown above quicksearch widget.
