### PR TITLE
Model: "dirty" fix nr.3

### DIFF
--- a/lib/Model.php
+++ b/lib/Model.php
@@ -130,7 +130,7 @@ class Model extends AbstractModel implements ArrayAccess,Iterator,Serializable {
         if ($value !== undefined 
             && (
                 // if data[$name] is not initialized at all (for example, in model using array controller)
-                !isset($this->data[$name])
+                (is_array($this->data) && !array_key_exists($name, $this->data))
                 // value as object
                 || is_object($value)
                 || is_object($this->data[$name])


### PR DESCRIPTION
Yes I know, I know ...
There still was problem with situations when:
1) $this->data itself is null !? Can't explain why this happens - probably some ATK4 magic :)
2) $this->data[$name] is initialized, but it's value is NULL. As result isset($this->data[$name]) still return false if value of array element is NULL.

well - this change fix both cases.
