### PR TITLE
jQuery_Chain: support for "ui" parameter

### DIFF
--- a/lib/jQuery/Chain.php
+++ b/lib/jQuery/Chain.php
@@ -242,15 +242,16 @@ class jQuery_Chain extends AbstractModel {
             if($this->str)$ret.="$('#".$this->owner->getJSID()."')";
         }
         $ret.=$this->str;
-        if($this->enclose===true){
-            if($this->preventDefault){
-                $ret="function(ev){ev.preventDefault();ev.stopPropagation(); ".$ret." }";
-            }else{
-                $ret="function(){ ".$ret." }";
-            }
-        }elseif($this->enclose){
-            $ret=($this->library?:"$('#".$this->owner->getJSID()."')").
-                ".bind('".$this->enclose."',function(ev){ ev.preventDefault();ev.stopPropagation(); ".$ret." })";
+        if ($this->enclose===true) {
+            $ret =  "function(e,ui){" .
+                        ($this->preventDefault ? "e.preventDefault();e.stopPropagation();" : "") .
+                        $ret .
+                    "}";
+        } elseif($this->enclose) {
+            $ret = ($this->library ?: "$('#".$this->owner->getJSID()."')") .
+                    ".bind('".$this->enclose."',function(e,ui){".
+                        ($this->preventDefault ? "e.preventDefault();e.stopPropagation();" : "") .
+                        $ret."})";
         }
         if(@$this->debug){
             echo "<font color='blue'>".htmlspecialchars($ret).";</font><br/>";


### PR DESCRIPTION
1) jQuery-UI mostly use callback `functions like function(e,ui){...}`. It was kind of hacky to add this `ui` parameter into JS function parameter list. Now it'll be already there by default for developers.
2) added preventDefault support in custom library case.

Example,

```
$this->options['active'] = // should be JS function with 'ui' parameter
    $this->js(null,'
        $url = $(ui.newHeader[0]).children("a").attr("href"); // use ui parameter here
        $.get($url, function (data) {
            $(ui.newHeader[0]).next().html(data);
        });
    ')->_enclose(null,true);

will generate:
function(e,ui) {
    e.preventDefault();
    e.stopDefault();
    $url = $(ui.newHeader[0]).children("a").attr("href"); // use ui parameter here
    $.get($url, function (data) {
        $(ui.newHeader[0]).next().html(data);
    });
}
```
