### PR TITLE
Logger: Resource type

### DIFF
--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -552,7 +552,7 @@ class Logger extends AbstractController {
                         $args .= "Object(".get_class($a).")";
                         break;
                     case 'resource':
-                        $args .= "Resource(".strstr($a, '#').")";
+                        $args .= "Resource(".get_resource_type($a).")";
                         break;
                     case 'boolean':
                         $args .= $a ? 'True' : 'False';


### PR DESCRIPTION
Relying on resource conversion to string and searching for # number is not good because even in php.net there is written "naming Resource #999 is subject to change".
Also I got strange situation today where resource couldn't get converted to string and function strstr() throw error that first parameter of strstr() should be string.
