### PR TITLE
normalize exception name

### DIFF
--- a/lib/AbstractObject.php
+++ b/lib/AbstractObject.php
@@ -527,12 +527,12 @@ abstract class AbstractObject
             $type = $this->default_exception;
         } elseif ($type[0] == '_') {
             if ($this->default_exception == 'BaseException') {
-                $type = 'Exception_'.substr($type, 1);
+                $type = 'Exception' . $type;
             } else {
-                $type = $this->default_exception.'_'.substr($type, 1);
+                $type = $this->default_exception . $type;
             }
-        } elseif ($type != 'BaseException' && strpos($type, 'Exception_') !== 0 && strpos($type, 'Exception_') === false) {
-            $type = 'Exception_'.$type;
+        } elseif ($type != 'BaseException') {
+            $type = $this->api->normalizeClassName($type, 'Exception');
         }
 
         // Localization support


### PR DESCRIPTION
This way it'll work better. It looks that this method can be even more simplified, but ... maybe some other time :)

Test cases of normalizeClassName:

```
$a = array(
    'Exception',
    'MoreException',
    'More_Exception_Foo',
    'Exception_Foo',

    'one/Exception',
    'one/MoreException',
    'one\More_Exception_Foo',
    'one/Exception_Foo',

    'one/two/Exception',
    'one/two/MoreException',
    'one\two/More_Exception_Foo',
    'one/two/Exception_Foo',
);
foreach($a as $s) {
    echo $api->normalizeClassName($s,'Exception')."\n";
}
```

output:

```
Exception
Exception_MoreException
Exception_More_Exception_Foo
Exception_Foo
one\Exception
one\Exception_MoreException
one\Exception_More_Exception_Foo
one\Exception_Foo
one\two\Exception
one\two\Exception_MoreException
one\two\Exception_More_Exception_Foo
one\two\Exception_Foo
```
