### PR TITLE
Loader: don't rely on current working directory

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -1,8 +1,18 @@
 <?php
-// This sets initial path for the include. Further includes will be initialized through PathFinder
-set_include_path('.'.PATH_SEPARATOR.'.'.DIRECTORY_SEPARATOR.'lib'.PATH_SEPARATOR.dirname(__FILE__).'/lib');
+// This sets initial path for the include.
+// Further includes will be initialized through PathFinder.
+$places = array(
+    dirname($_SERVER['PHP_SELF']),
+    dirname($_SERVER['PHP_SELF']) . DIRECTORY_SEPARATOR . 'lib',
+    __DIR__  . DIRECTORY_SEPARATOR . 'lib',
+);
+set_include_path(join(PATH_SEPARATOR, $places));
+
+// check PHP version requirements
 if (version_compare(PHP_VERSION, '5.3.0') < 0) {
     echo 'PHP 5.3.0 is required';
     exit;
 }
+
+// include some static functions
 require'static.php';


### PR DESCRIPTION
If your current working directory is not the same as index.php directory, then simple relative paths will not work.
It's better and more correct to use dirname($_SERVER[PHP_SELF]) instead.

This is especially true if you use CLI type of script which is called from console like this:

```
/usr/bin/php -f /srv/www/htdocs/test/index.php >> /srv/www/htdocs/test/log/`date +"%Y%m%d"`"-index.log"
```

Where current directory is not obligatory the same where your index.php file resides. Currently this didn't work and you had to call script like this:

```
cd /srv/www/htdocs/test
/usr/bin/php -f index.php >> log/`date +"%Y%m%d"`"-index.log"
```

to make it work which is not always good.
