### PR TITLE
Partly roll back "performance upgrade"

### DIFF
--- a/lib/AbstractObject.php
+++ b/lib/AbstractObject.php
@@ -1052,7 +1052,7 @@ abstract class AbstractObject
         }
         $postfix = count($array);
         $attempted_key = $desired;
-        while (isset($array[$attempted_key])) {
+        while (array_key_exists($attempted_key, $array)) {
             // already used, move on
             $attempted_key = $desired . '_' . (++$postfix);
         }


### PR DESCRIPTION
Because isset() works faster than array_key_exists, but it's not the same. Problems start with NULL values.
More info here: http://stackoverflow.com/a/3210982/1466341

In my particular case when I use isset() then Model/DSQL generate wrong SELECTs replacing all NULL values in where() or addCondition() with some numbers, like "6". Not sure where's the problem, but better roll back this.
