### PR TITLE
QuickSearch: remove spaces around value

### DIFF
--- a/lib/QuickSearch.php
+++ b/lib/QuickSearch.php
@@ -99,7 +99,7 @@ class QuickSearch extends Filter
     function postInit()
     {
         parent::postInit();
-        if(!($v = $this->get('q'))) {
+        if(!($v = trim($this->get('q')))) {
             return;
         }
 


### PR DESCRIPTION
Remove spaces in beginning or end of POSTed value.
We don't need them in "%like%" type of comparison.
