### PR TITLE
BaseException: there's no global backtrace method

### DIFF
--- a/lib/BaseException.php
+++ b/lib/BaseException.php
@@ -165,7 +165,8 @@ class BaseException extends Exception
             '<p><font color=blue>' . $this->getMyFile() . ':' .
             $this->getMyLine() . '</font></p>' .
             $this->getDetailedHTML() .
-            backtrace($this->shift + 1, $this->getMyTrace());
+            '' //backtrace($this->shift + 1, $this->getMyTrace())
+            ;
         
         return $html;
     }


### PR DESCRIPTION
Dirty solution for https://github.com/atk4/atk4/issues/444, but at least that'll not throw fatal exceptions
