### PR TITLE
For Multi Authentication system

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -55,12 +55,15 @@ class Auth_Basic extends AbstractController {
 
     public $hash_algo=PASSWORD_DEFAULT;
     public $hash_options=array();
+    public $is_default_auth_system=true;
 
     function init(){
         parent::init();
 
-        // Register as auth handler.
-        $this->api->auth=$this;
+        if($this->is_default_auth_system){
+            // Register as auth handler.
+            $this->api->auth=$this;
+        }
 
         if (!$this->api->hasMethod('initializeSession')) {
             // No session support


### PR DESCRIPTION
Every new object of Auth_Basic is added to api->auth... Not good for multiple authentication system where one authentication system is added to Frontend as default but various sub sections may have their own auth systems that must not replace api ->auth every time.
