### PR TITLE
Fix inconsistent hooks: Model.php & SQL/Model.php

### DIFF
--- a/lib/SQL/Model.php
+++ b/lib/SQL/Model.php
@@ -675,14 +675,16 @@ class SQL_Model extends Model {
         }
 
         // Performs the actual database changes. Throw exceptions if problem occurs
-        $this->hook('beforeUpdate',array($modify));
+	$this->hook('beforeUpdate',array($modify));
+	$this->hook('beforeModify',array($modify));
         if($modify->args['set'])$modify->do_update();
 
         if($this->dirty[$this->id_field]){
             $this->id=$this->get($this->id_field);
         }
 
-        $this->hook('afterUpdate');
+	$this->hook('afterUpdate');
+	$this->hook('afterModify');
 
         if($this->_save_as===false)return $this->unload();
         $id=$this->id;

--- a/lib/SQL/Model.php
+++ b/lib/SQL/Model.php
@@ -675,14 +675,14 @@ class SQL_Model extends Model {
         }
 
         // Performs the actual database changes. Throw exceptions if problem occurs
-        $this->hook('beforeModify',array($modify));
+        $this->hook('beforeUpdate',array($modify));
         if($modify->args['set'])$modify->do_update();
 
         if($this->dirty[$this->id_field]){
             $this->id=$this->get($this->id_field);
         }
 
-        $this->hook('afterModify');
+        $this->hook('afterUpdate');
 
         if($this->_save_as===false)return $this->unload();
         $id=$this->id;


### PR DESCRIPTION
Going on from pull request **"added missing hooks #484"** https://github.com/atk4/atk4/pull/484

I dug a little deeper - and as you say the hooks weren't missing but are in fact named inconsistently between the two classes...

Hooks in Model.php were: "beforeUpdate" & "afterUpdate" (See links below)
Hooks in SQL/Model.php were: "beforeModify" & "afterModify" (Again,
links below)

The names of the hooks in Model.php make more sense (at least to me)
and when used in SQL follow with the UPDATE statement that is generated.
Therefore I have changed the names of the hooks in SQL/Model.php to match
those in Model.php

https://github.com/atk4/atk4/blob/7b97da192658af4b08e34039106984f31a248265/lib/Model.php#L360
https://github.com/atk4/atk4/blob/7b97da192658af4b08e34039106984f31a248265/lib/Model.php#L368

https://github.com/atk4/atk4/blob/7b97da192658af4b08e34039106984f31a248265/lib/SQL/Model.php#L678
https://github.com/atk4/atk4/blob/7b97da192658af4b08e34039106984f31a248265/lib/SQL/Model.php#L685