### PR TITLE
Allow to pass DSQL expression + condition + value

### DIFF
--- a/lib/SQL/Model.php
+++ b/lib/SQL/Model.php
@@ -271,9 +271,9 @@ class SQL_Model extends Model implements Serializable {
 
         // TODO: refactor using parent:: conditions (through array)
 
-        // You may pass plain "dsql" expressions as a first argument
-        if($field instanceof DB_dsql && $cond===undefined && $value===undefined){
-            $this->_dsql()->where($field);
+        // You may pass plain "dsql" expression as a first argument
+        if($field instanceof DB_dsql){
+            $this->_dsql()->where($field, $cond, $value);
             return $this;
         }
 


### PR DESCRIPTION
Very useful in situations like this:

```
// TASK: select distinct clients which have at least one unpaid invoice

$m = $this->add('Model_Client');
$m->_dsql()->option('DISTINCT');

// join invoice table (1:n relation)
$j = $m->leftJoin('invoice.client_id', 'id');

// this way it worked already, but only for DSQL->where()
$m->_dsql()->where($j->fieldExpr('sum_unpaid'), '>', 0);

// but model addCondition passed to its _dsql->where() only first parameter if
// its DSQL expression itself and not condition and value parameters
$m->addCondition($j->fieldExpr('sum_unpaid'), '>', 0);
```
