### PR TITLE
Important fix to treat NULL values in conditions (Model & DSQL) correctly

### DIFF
--- a/lib/DB/dsql.php
+++ b/lib/DB/dsql.php
@@ -603,8 +603,8 @@ class DB_dsql extends AbstractModel implements Iterator {
                 if (is_array($row)) {
                     $or->where(
                         $row[0],
-                        isset($row[1])?$row[1]:UNDEFINED,
-                        isset($row[2])?$row[2]:UNDEFINED
+                        array_key_exists(1, $row) ? $row[1] : UNDEFINED,
+                        array_key_exists(2, $row) ? $row[2] : UNDEFINED
                     );
                 } elseif (is_object($row)) {
                     $or->where($row);
@@ -720,7 +720,7 @@ class DB_dsql extends AbstractModel implements Iterator {
                 $value = explode(',', $value);
             }
 
-            // if value is array, then us IN or NOT IN as condition
+            // if value is array, then use IN or NOT IN as condition
             if (is_array($value)) {
                 $v=array();
                 foreach ($value as $vv) {

--- a/lib/SQL/Model.php
+++ b/lib/SQL/Model.php
@@ -326,8 +326,8 @@ class SQL_Model extends Model {
                 }
                 // add each condition to OR expression (not models DSQL)
                 $f = $row[0];
-                $c = isset($row[1]) ? $row[1] : undefined;
-                $v = isset($row[2]) ? $row[2] : undefined;
+                $c = array_key_exists(1, $row) ? $row[1] : undefined;
+                $v = array_key_exists(2, $row) ? $row[2] : undefined;
 
                 // recursively calls addCondition method, but adds conditions
                 // to OR expression not models DSQL object


### PR DESCRIPTION
In PHP `isset($row[1])` returns `false` if value in $row[1] is set, but it's NULL
(not UNDEFINED constant) and as result condition is not set at all or set
incorrectly. This bug was there long ago :)

Some test cases:

```
// field given as string or DSQL or model Field
$fields = array('name', $q->expr('now()'), $m->getElement('name'));
foreach($fields as $field) {
    $m->addCondition(array(
        // NULL value
        array($field,null),
        array($field,'=',null),
        array($field,'is',null),
        array($field,'<>',null),
        array($field,'is not',null),
        array($field,'not',null),
        // ARRAY value
        array($field,array(1,2)),
        array($field,'=',array(1,2)),
        array($field,'in',array(1,2)),
        array($field,'<>',array(1,2)),
        array($field,'not in',array(1,2)),
        array($field,'not',array(1,2)),
    ));
}
```
