### PR TITLE
Update Basic.php

### DIFF
--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -396,6 +396,7 @@ class Grid_Basic extends CompleteLister
             } else {
                 $header_col
                     ->del('sort')
+                    ->tryDel('sortid')
                     ->tryDel('sort_del');
             }
 


### PR DESCRIPTION
Should remove `id` element from HTML template in case this column is not sortable. Otherwise `id` from previous sortable column is left in template.
