### PR TITLE
CRUD->addRef, custom model for sub-View

### DIFF
--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -267,6 +267,7 @@ class View_CRUD extends View
      * array (
      *   'view_class' => 'CRUD',  // Which View to use inside expander
      *   'view_options' => ..     // Second arg when adding view.
+     *   'view_model' => model or callback // Use custom model for sub-View, by default ref($name) will be used
      *   'fields' => array()      // Used as second argument for setModel()
      *   'extra_fields' => array() // Third arguments to setModel() used by CRUDs
      *   'label'=> 'Click Me'     // Label for a button inside a grid
@@ -312,8 +313,14 @@ class View_CRUD extends View
                 $options['view_options']
             );
 
+            $this->model->load($this->id);
             $subview->setModel(
-                $this->model->load($this->id)->ref($name),
+                $options['view_model']
+                    ? (is_callable($options['view_model'])
+                        ? call_user_func($options['view_model'], $this->model)
+                        : $options['view_model']
+                    )
+                    : $this->model->ref($name),
                 $options['fields'],
                 $options['grid_fields']?:$options['extra_fields']
             );


### PR DESCRIPTION
Now CRUD->addRef can use custom models for sub-View.
That's especially handy when you need deep references, for example, in case of n:m relationship.

Imagine models: `Client --< DocumentRelation >-- Document`.
I have CRUD of clients and I want to add expander for CRUD of Document (not DocumentRelation).
So now I can do simply like this:

```
$sub = $client->addRef('Document', array(
    'view_model' => function($model) { // model is already loaded with appropriate Client record
        $d = $model->add('Model_Document');
        $d->addCondition($d->id_field, 'in',
                        $model->ref('DocumentRelation')->fieldQuery('document_id'));
        return $d;
    },
));
```

Using custom model for sub-View you can construct very fancy models too - just use your imagination :)