### PR TITLE
Totals calculation features / fixes

### DIFF
--- a/lib/CompleteLister.php
+++ b/lib/CompleteLister.php
@@ -105,6 +105,7 @@ class CompleteLister extends Lister
      * Enable totals calculation for specified array of fields
      *
      * If particular fields not specified, then all field totals are calculated.
+     * If you only need to count records, then pass null and no fields will be calculated.
      *
      * Be aware that if you use Paginator, then only records of current page
      * will be calculated. If you need grand totals for all records, then use
@@ -114,7 +115,7 @@ class CompleteLister extends Lister
      *
      * @return $this
      */
-    function addTotals($fields = null)
+    function addTotals($fields = UNDEFINED)
     {
         return $this->_addTotals($fields, 'onRender');
     }
@@ -123,6 +124,7 @@ class CompleteLister extends Lister
      * Enable totals calculation for specified array of fields
      *
      * If particular fields not specified, then all field totals are calculated.
+     * If you only need to count records, then pass null and no fields will be calculated.
      *
      * Be aware that this method works ONLY for SQL models set as data source
      * because this calculates grand totals using DSQL.
@@ -131,7 +133,7 @@ class CompleteLister extends Lister
      *
      * @return $this
      */
-    function addGrandTotals($fields = null)
+    function addGrandTotals($fields = UNDEFINED)
     {
         if (!$this->getIterator() instanceof SQL_Model) {
             throw $this->exception("Grand Totals can be used only with SQL_Model data source");
@@ -155,13 +157,14 @@ class CompleteLister extends Lister
      * of fields
      *
      * If particular fields not specified, then all field totals are calculated.
+     * If you only need to count records, then pass null and no fields will be calculated.
      *
      * @param array $fields optional array of fieldnames
      * @param string $type type of totals calculation (null|onRender|onRequest)
      *
      * @return $this
      */
-    protected function _addTotals($fields = null, $type = null)
+    protected function _addTotals($fields = UNDEFINED, $type = null)
     {
         // set type
         $this->totals_type = $type;
@@ -173,7 +176,7 @@ class CompleteLister extends Lister
 
         // if no fields defined then get available fields from model
         $iter = $this->getIterator();
-        if (!$fields && $iter->hasMethod('getActualFields')) {
+        if ($fields === UNDEFINED && $iter->hasMethod('getActualFields')) {
             $fields = $iter->getActualFields();
         }
 
@@ -181,7 +184,7 @@ class CompleteLister extends Lister
         if ($this->totals === false) {
             $this->totals = array();
         }
-        if ($fields) {
+        if (is_array($fields)) {
             foreach ($fields as $field) {
                 $this->totals[$field] = 0;
             }
@@ -221,18 +224,10 @@ class CompleteLister extends Lister
         foreach ($iter as $this->current_id=>$this->current_row) {
             $this->current_row_html=array();
 
-            // if totals enabled, but specific fields are not specified with
-            // addTotals, then calculate totals for all available fields
-            if ($this->totals === array()) {
-                foreach ($this->current_row as $k=>$v) {
-                    $this->totals[$k] = 0;
-                }
-            }
-
             // calculate rows so far
             $this->total_rows++;
 
-            // if onRender totals enabled, then execute
+            // if onRender totals enabled, then update totals
             if ($this->totals_type == 'onRender') {
                 $this->updateTotals();
             }
@@ -365,7 +360,7 @@ class CompleteLister extends Lister
 
         // create DSQL query for sum and count request
         $fields = array_keys($this->totals);
-        $q = $m->sum($fields)->del('limit');
+        $q = $m->sum($fields)->del('limit')->del('order');
         $q->field($q->count(), 'total_cnt');
 
         // execute DSQL


### PR DESCRIPTION
In some situation you only need to show total count of rows in grid and don't need to calculate totals for any column (field). In such case before all fields was automatically added from model. Now we can pass addTotals(null) or addTotals(false) and get what we need - only count records, but no totals for fields will be calculated.
