### PR TITLE
To correctly calculate grandTotals (for 4.2.x)

### DIFF
--- a/lib/CompleteLister.php
+++ b/lib/CompleteLister.php
@@ -360,7 +360,15 @@ class CompleteLister extends Lister
 
         // create DSQL query for sum and count request
         $fields = array_keys($this->totals);
-        $q = $m->sum($fields)->del('limit')->del('order');
+
+        // select as sub-query
+        $sub_q = $m->dsql()->del('limit')->del('order');
+        
+        $q = $this->api->db->dsql();//->debug();
+        $q->table($sub_q, 'grandTotals'); // alias is mandatory if you pass table as DSQL
+        foreach ($fields as $field) {
+            $q->field($q->sum($field), $field);
+        }
         $q->field($q->count(), 'total_cnt');
 
         // execute DSQL


### PR DESCRIPTION
To correctly calculate grandTotals in some cases when you don't have completely distinct records in your Lister or more likely - Grid. For example, if Grid Model has joined table etc.

Before:

```
select DISTINCT SQL_CALC_FOUND_ROWS
    sum((select sum(`invoice`.`sum_unpaid`) `sum_unpaid` from `invoice` where `invoice`.`client_id` = `client`.`id` )) `sum_unpaid`,
    count(*) `total_cnt`
from `client`
    left join `invoice` as `_i` on `_i`.`client_id` = `client`.`id`
where
    ...
```

if you have more than one invoice for a client (rows are not distinct anymore), then SUM will be wrong.

After:

```
select
    sum(`sum_unpaid`) `sum_unpaid`,
    count(*) `total_cnt`
from (
    select DISTINCT 
        ...,
        (select sum(`invoice`.`sum_unpaid`) `sum_unpaid` from `invoice` where `invoice`.`client_id` = `client`.`id` ) `sum_unpaid`,
        ...
    from `client`
        left join `invoice` as `_i` on `_i`.`client_id` = `client`.`id`
    where ...
    ) `grandTotals`
```

now you shouldn't care are your rows distinct or not or whatever because SUM are calculated using sub-select.

That way it will work a bit slower, but always correctly what is more important I guess :)
