### PR TITLE
empty string is not the same as 0 (for 4.2.x)

### DIFF
--- a/lib/Form/Field/DropDown.php
+++ b/lib/Form/Field/DropDown.php
@@ -39,7 +39,7 @@ class Form_Field_DropDown extends Form_Field_ValueList {
     }
     function getOption($value){
         $selected = false;
-        if($this->value===null){
+        if($this->value===null || $this->value===''){
             $selected = $value==='';
         } else {
             $selected = $value == $this->value;


### PR DESCRIPTION
If $this->value was (string)"" and $value was (int) 0, then both options ("" and 0) was set as selected.
