### PR TITLE
empty string is not the same as 0 (for 4.3)

### DIFF
--- a/lib/Form/Field/DropDown.php
+++ b/lib/Form/Field/DropDown.php
@@ -41,9 +41,15 @@ class Form_Field_DropDown extends Form_Field_ValueList {
         return $output;
     }
     function getOption($value){
+        $selected = false;
+        if($this->value===null || $this->value===''){
+            $selected = $value==='';
+        } else {
+            $selected = $value == $this->value;
+        }
         return $this->getTag('option',array(
                     'value'=>$value,
-                    'selected'=>$value == $this->value
-                    ));
+                    'selected'=>$selected
+        ));
     }
 }


### PR DESCRIPTION
If $this->value was (string)"" and $value was (int) 0, then both options ("" and 0) was set as selected.
