### PR TITLE
missing cut() (for 4.2)

### DIFF
--- a/lib/VirtualPage.php
+++ b/lib/VirtualPage.php
@@ -180,6 +180,7 @@ class VirtualPage extends AbstractController
             null,
             $this->page_template
         );
+        $this->api->cut($this->page);
         $this->api->stickyGET($this->name);
         return $this->page;
     }


### PR DESCRIPTION
This is what was missing and that's because nested CRUDs didn't work as expected.
But that don't solve anything. It's just possibly a step forward :)
