### PR TITLE
VirtualPage shouldn't use "cut_object" (4.3)

### DIFF
--- a/lib/VirtualPage.php
+++ b/lib/VirtualPage.php
@@ -138,17 +138,10 @@ class VirtualPage extends AbstractController
 
         if ($this->isActive($arg)) {
             $this->api->addHook('post-init', function () use ($method, $self) {
-                $page=$self->api->add(
-                    $self->page_class,
-                    $self->name,
-                    null,
-                    $self->page_template
-                );
+                $page = $self->getPage();
                 $page->id=$_GET[$self->name.'_id'];
-
-                $self->api->cut($page);
-                $self->api->stickyGET($self->name);
                 $self->api->stickyGET($self->name.'_id');
+                
                 try {
                     call_user_func($method, $page, $self);
                 } catch (Exception $e){
@@ -156,8 +149,10 @@ class VirtualPage extends AbstractController
                     // are already executing from post-init, so
                     // it's fine to ignore it.
                 }
-                $self->api->stickyForget($self->name.'_id');
-                $self->api->stickyForget($self->name);
+                
+                //Imants: most likely forgetting is not needed, because we stop execution anyway
+                //$self->api->stickyForget($self->name.'_id');
+                //$self->api->stickyForget($self->name);
             });
             throw $this->exception('', 'StopInit');
         }


### PR DESCRIPTION
Full test case:

```
<?php
// PAGE ===================================================
class page_tabztest extends Page {
    public $title='Tabz test';

    function init() {
        parent::init();
        $this->add('View_Box')->setHTML('This is main page content, rand='.rand());

        // add CRUD
        $c = $this->add('CRUD', array('form_class'=>'Tabz'));
        $c->setModel('Parent');

        if ($c->isEditing()) {
            // static Tab = WORKS
            $c->form->addTab('Static Tab')->add('LoremIpsum');

            // ajax Tab = ISSUES WITH NESTED VIRTUAL PAGES OR CRUDs
            $c->form->addAjaxTab('Ajax 1');
            $c->form->addAjaxTab('Ajax 2');
        }
    }
}

// TABS VIEW ==============================================
class Tabz extends Tabs{
    public $main_tab;   // link to 1st tab
    public $form;       // link to form in 1st tab
    public $model;      // model of 1st tab form

    function init(){
        parent::init();

        $this->main_tab = $this->addTab('Main');
        $this->form = $this->main_tab->add('Form');
    }

    function setModel($model,$fields){
        $this->model = $this->form->setModel($model,$fields);
        return $this->model;
    }

    function addAjaxTab($title) {
        $self = $this;

        $vp1 = $this->add('VirtualPage','vp');
        $this->addTabURL($vp1->getURL(), $title);

        $vp1->set(function($p) use($self) {

            // WORKING
            $p->add('View_Box')->setHTML('Record ID=' . $self->model->id . ', rand='.rand());
            $p->add('View_Box')->setHTML(nl2br(var_export($_GET,true)));

            // testing subCRUD - NOT WORKING EDIT/ADD etc.
            $c = $p->add('CRUD');
            $c->setModel('Model_Child');//->addCondition('parent_id', $self->model->id);
        });
    }

    function addSubmit($x='OK'){
        return $this->form->addSubmit($x);
    }
    function onSubmit($x){
        return $this->form->onSubmit($x);
    }
}

// MODELS =================================================
class Model_Parent extends Model {
    function init(){
        parent::init();

        $this->addField('name');
        $this->addField('surname');

        $this->setSource('Array',array(
            array('id'=>1, 'name'=>'john', 'surname'=>'smith'),
            array('id'=>2, 'name'=>'harry', 'surname'=>'poter'),
            array('id'=>3, 'name'=>'tom', 'surname'=>'tomtom'),
            array('id'=>4, 'name'=>'mary', 'surname'=>'queen'),
        ));
    }
}
class Model_Child extends Model {
    function init(){
        parent::init();

        $this->addField('name');
        $this->addField('surname');

        $this->setSource('Array',array(
            array('id'=>1, 'parent_id'=>1, 'name'=>'kiddo', 'surname'=>'smith'),
            array('id'=>2, 'parent_id'=>2, 'name'=>'kiddy', 'surname'=>'poter'),
            array('id'=>3, 'parent_id'=>2, 'name'=>'teddy', 'surname'=>'poter'),
        ));
    }
}
```
