### PR TITLE
Load model before applying it to Form

### DIFF
--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -437,8 +437,7 @@ class View_CRUD extends View
     {
         // We are actually in the frame!
         if ($this->isEditing('edit')) {
-            $m = $this->form->setModel($this->model, $fields);
-            $m->load($this->id);
+            $m = $this->form->setModel($this->model->load($this->id), $fields);
             $this->form->addSubmit();
             $this->form->onSubmit(array($this,'formSubmit'));
             return $m;


### PR DESCRIPTION
it's loaded anyway in next line, so there is no point to split this in two lines.
- fix some issues with "what is loaded when" (Skype conversation)
- better performance, because already loaded model is applied to form, so form can fill its values instantly
