### PR TITLE
Shared utility method for encoding HTML special chars

### DIFF
--- a/lib/ApiCLI.php
+++ b/lib/ApiCLI.php
@@ -524,5 +524,26 @@ class ApiCLI extends AbstractView
         }
         return $name;
     }
+    /**
+     * Encodes HTML special chars, but not already encoded ones by default
+     *
+     * @param string $s
+     * @param int $flags
+     * @param string $encoding
+     * @param bool $double_encode
+     *
+     * @return string
+     */
+    function encodeHtmlChars($s, $flags = undefined, $encode = undefined, $double_encode = false)
+    {
+        if ($flags === undefined) {
+            $flags = ENT_COMPAT;
+        }
+        if ($encode === undefined) {
+            $encode = ini_get("default_charset") ?: 'UTF-8';
+        }
+        
+        return htmlspecialchars($s, $flags, $encode, $double_encode);
+    }
     // }}}
 }

--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -380,7 +380,7 @@ abstract class Form_Field extends AbstractView {
             if($val === false) continue;
             if($val === true) $tmp[] = "$key";
             elseif($key === '')$tag=$val;
-            else $tmp[] = "$key=\"".htmlspecialchars($val)."\"";
+            else $tmp[] = "$key=\"".$this->api->encodeHtmlChars($val)."\"";
         }
         return "<$tag ".join(' ',$tmp).$postfix.">".($value?$value."</$tag>":"");
     }

--- a/lib/Form/Field/CheckboxList.php
+++ b/lib/Form/Field/CheckboxList.php
@@ -57,7 +57,7 @@ class Form_Field_CheckboxList extends Form_Field_ValueList
                         'value'=>$value,
                         'checked'=>in_array($value,$current_values)
                     ),$this->attr,$attr)) .
-                '<label for="'.$this->name.'_'.$value.'">'.htmlspecialchars($descr).'</label>' .
+                '<label for="'.$this->name.'_'.$value.'">'.$this->api->encodeHtmlChars($descr).'</label>' .
                 '</td>';
             $i++;
             $column++;

--- a/lib/Form/Field/DateSelector.php
+++ b/lib/Form/Field/DateSelector.php
@@ -224,7 +224,7 @@ class Form_Field_DateSelector extends Form_Field {
                             'value'=>$value,
                             'selected'=>$value == $this->c_day,
                             ))
-                .htmlspecialchars($descr)
+                .$this->api->encodeHtmlChars($descr)
                 .$this->getTag('/option');
         }
         $d.=$this->getTag('/select').'&nbsp;';
@@ -242,7 +242,7 @@ class Form_Field_DateSelector extends Form_Field {
                             'value'=>$value,
                             'selected'=>$value == $this->c_month
                             ))
-                .htmlspecialchars($descr)
+                .$this->api->encodeHtmlChars($descr)
                 .$this->getTag('/option');
         }
         $m.=$this->getTag('/select').'&nbsp;';
@@ -260,7 +260,7 @@ class Form_Field_DateSelector extends Form_Field {
                             'value'=>$value,
                             'selected'=>$value == $this->c_year
                             ))
-                .htmlspecialchars($descr)
+                .$this->api->encodeHtmlChars($descr)
                 .$this->getTag('/option');
         }
         $y.=$this->getTag('/select');

--- a/lib/Form/Field/DropDown.php
+++ b/lib/Form/Field/DropDown.php
@@ -31,7 +31,7 @@ class Form_Field_DropDown extends Form_Field_ValueList {
             // Check if a separator is not needed identified with _separator<
             $output.=
                 $this->getOption($value)
-                .htmlspecialchars($descr)
+                .$this->api->encodeHtmlChars($descr)
                 .$this->getTag('/option');
         }
         $output.=$this->getTag('/select');

--- a/lib/Form/Field/Radio.php
+++ b/lib/Form/Field/Radio.php
@@ -28,7 +28,7 @@ class Form_Field_Radio extends Form_Field_ValueList {
             if($descr instanceof AbstractView){
                 $descr=$descr->getHTML();
             }else{
-                $descr=htmlspecialchars($descr);
+                $descr=$this->api->encodeHtmlChars($descr);
             }
 
             $output.=

--- a/lib/Form/Field/Text.php
+++ b/lib/Form/Field/Text.php
@@ -14,7 +14,7 @@ class Form_Field_Text extends Form_Field {
     function getInput($attr=array()){
         return
             parent::getInput(array_merge(array(''=>'textarea'),$attr)).
-            htmlspecialchars($this->value,ENT_COMPAT,'ISO-8859-1',false).
+            $this->api->encodeHtmlChars($this->value).
             $this->getTag('/textarea');
     }
 }

--- a/lib/Grid/Advanced.php
+++ b/lib/Grid/Advanced.php
@@ -1011,7 +1011,7 @@ class Grid_Advanced extends Grid_Basic
         $this->current_row[$field] = $text;
         
         $this->setTDParam($field, 'title',
-            htmlspecialchars($this->current_row[$field.'_original']));
+            $this->api->encodeHtmlChars($this->current_row[$field.'_original']));
     }
 
     /**

--- a/lib/SMlite.php
+++ b/lib/SMlite.php
@@ -249,12 +249,14 @@ class SMlite extends AbstractModel {
          */
         if($value instanceof URL)$value=$value->__toString();
         // Temporary here until we finish testing
-        if($encode && $value!=htmlspecialchars($value,ENT_NOQUOTES,'UTF-8') && $this->api->getConfig('html_injection_debug',false))throw $this->exception('Attempted to supply html string through append()')
-            ->addMoreInfo('val',var_export($value,true))
-            ->addMoreInfo('enc',var_export(htmlspecialchars($value,ENT_NOQUOTES,'UTF-8'),true))
-            //->addAction('ignore','Ignore tag'.$tag)
-            ;
-        if($encode)$value=htmlspecialchars($value,ENT_NOQUOTES,'UTF-8');
+        if($encode && $value!=$this->api->encodeHtmlChars($value,ENT_NOQUOTES) && $this->api->getConfig('html_injection_debug',false)) {
+            throw $this->exception('Attempted to supply html string through append()')
+                ->addMoreInfo('val',var_export($value,true))
+                ->addMoreInfo('enc',var_export($this->api->encodeHtmlChars($value,ENT_NOQUOTES),true))
+                //->addAction('ignore','Ignore tag'.$tag)
+                ;
+        }
+        if($encode)$value=$this->api->encodeHtmlChars($value,ENT_NOQUOTES);
         if($this->isTopTag($tag)){
             $this->template[]=$value;
             return $this;
@@ -266,7 +268,7 @@ class SMlite extends AbstractModel {
         foreach($this->tags[$tag] as $key=>$_){
 
             if(!is_array($this->tags[$tag][$key])){
-                //throw new BaseException("Problem appending '".htmlspecialchars($value)."' to '$tag': key=$key");
+                //throw new BaseException("Problem appending '".$this->api->encodeHtmlChars($value)."' to '$tag': key=$key");
                 $this->tags[$tag][$key]=array($this->tags[$tag][$key]);
             }
             $this->tags[$tag][$key][]=$value;
@@ -342,12 +344,14 @@ class SMlite extends AbstractModel {
         if($value instanceof URL)$value=$value->__toString();
         if(is_array($value))return $this;
 
-        if($encode && $value!=htmlspecialchars($value,ENT_NOQUOTES,'UTF-8') && $this->api->getConfig('html_injection_debug',false))throw $this->exception('Attempted to supply html string through set()')
-            ->addMoreInfo('val',var_export($value,true))
-            ->addMoreInfo('enc',var_export(htmlspecialchars($value,ENT_NOQUOTES,'UTF-8'),true))
-            //->addAction('ignore','Ignore tag'.$tag)
-            ;
-        if($encode)$value=htmlspecialchars($value,ENT_NOQUOTES,'UTF-8');
+        if($encode && $value!=$this->api->encodeHtmlChars($value,ENT_NOQUOTES) && $this->api->getConfig('html_injection_debug',false)) {
+            throw $this->exception('Attempted to supply html string through set()')
+                ->addMoreInfo('val',var_export($value,true))
+                ->addMoreInfo('enc',var_export($this->api->encodeHtmlChars($value,ENT_NOQUOTES),true))
+                //->addAction('ignore','Ignore tag'.$tag)
+                ;
+        }
+        if($encode)$value=$this->api->encodeHtmlChars($value,ENT_NOQUOTES);
         if($this->isTopTag($tag)){
             $this->template=$value;
             return $this;

--- a/lib/Text.php
+++ b/lib/Text.php
@@ -34,6 +34,6 @@ class Text extends AbstractView {
         $this->html=$html;
     }
     function render(){
-        $this->output($this->html?:htmlspecialchars($this->text,ENT_NOQUOTES,'UTF-8'));
+        $this->output($this->html ?: $this->api->encodeHtmlChars($this->text, ENT_NOQUOTES));
     }
 }

--- a/lib/VirtualPage.php
+++ b/lib/VirtualPage.php
@@ -204,7 +204,7 @@ class VirtualPage extends AbstractController
         $grid->addColumn('template', $name, $buttontext?:$title)
             ->setTemplate(
                 '<button type="button" class="pb_'.$name.'">'.
-                htmlspecialchars(
+                $this->api->encodeHtmlChars(
                     $buttontext?:$title?:ucwords(
                         str_replace('_', ' ', $name)
                     )


### PR DESCRIPTION
- by default don't double encode already existing HTML chars (like `&nbsp;`)
- by default use `default_charset` encoding from ini file or fall back to `UTF-8` encoding
- replaced `htmlspecialchars` method in almost every ATK file except some where original method call is probably more appropriate (like debug messages)
