### PR TITLE
fix null options (for 4.2)

### DIFF
--- a/lib/View/Popover.php
+++ b/lib/View/Popover.php
@@ -30,19 +30,26 @@ class View_Popover extends View {
     /* Returns JS which will position this element and show it */
     function showJS($element=null,$options=array()){
 
-        $this->js(true)->dialog(array_extend(array(
-            'modal'=>true,
-            'dialogClass'=>$options['class']?:'popover',
-            'dragable'=>false,
-            'resizable'=>false,
-            'minHeight'=>'auto',
-            'autoOpen'=>false,
-            'width'=>250,
-            'open'=>$this->js(null, $this->js()->_selector('.ui-dialog-titlebar:last')->hide())->click(
-                $this->js()->dialog('close')->_enclose()
-            )->_selector('.ui-widget-overlay:last')->_enclose()->css('opacity','0'),
-        ),$options))->parent()->append('<div class="arrow '.($options['arrow']?:'vertical top left').'"></div>')
-        ;
+        $options = array_extend( array(
+                'modal'     => true,
+                'dialogClass' => $options['class'] ?: 'popover',
+                'dragable'  => false,
+                'resizable' => false,
+                'minHeight' => 'auto',
+                'autoOpen'  => false,
+                'width'     => 250,
+                'open'      => $this->js(null, $this->js()->_selector('.ui-dialog-titlebar:last')->hide())
+                    ->click($this->js()->dialog('close')->_enclose())
+                    ->_selector('.ui-widget-overlay:last')
+                    ->_enclose()
+                    ->css('opacity', '0'),
+            ),
+            $options ?: array()
+        );
+        
+        $this->js(true)->dialog($options)
+            ->parent()
+            ->append('<div class="arrow '.($options['arrow'] ?: 'vertical top left').'"></div>');
 
         return $this->js()->dialog('open')->dialog('option',array(
             'position'=>$p=array(


### PR DESCRIPTION
- fix: $options can be passed as null from View_Button, so `$options ?: array()` now helps in this case
- readability: merge default options with passed options before using them in chains
