### PR TITLE
move ADD button initialization in proper place

### DIFF
--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -181,10 +181,6 @@ class View_CRUD extends View
 
         // Left for compatibility
         $this->js('reload', $this->grid->js()->reload());
-
-        if ($this->allow_add) {
-            $this->add_button = $this->grid->addButton('Add');
-        }
     }
 
     /**
@@ -412,6 +408,7 @@ class View_CRUD extends View
         } elseif ($this->isEditing()) return;
 
         // Configure Add Button on Grid and JS
+        $this->add_button = $this->grid->addButton('Add');
         $this->add_button->js('click')->univ()
             ->frameURL(
                 $this->api->_($this->entity_name===false


### PR DESCRIPTION
I believe that "add" button should be moved inside configureAdd() method, because it's only used there and don't need another permission check.
That's important because if your model somehow "knows" user permissions on it, then it can only pass these permissions to CRUD after CRUD initialization - only with setModel() method. So, "add" button should be initialized after setModel and not instantly on CRUD initialization.
