### PR TITLE
CRUD, change add_button initialization (for 4.2)

### DIFF
--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -172,8 +172,8 @@ class View_CRUD extends View
                 ->virtual_page
                 ->getPage()
                 ->add($this->form_class, $this->form_options);
-                
-                return;
+
+            return;
         }
 
         $this->grid = $this->add($this->grid_class, $this->grid_options);


### PR DESCRIPTION
- [Add] button now will be initialized later if needed - only in `configureAdd()` method
- in CRUD->init we can't use `isEditing()` method because permissions of CRUD can change later in `setModel()`.
  For example, you can initialize CRUD by `$this->add('CRUD',['allow_add'=>false]);` but, when setting model, model can "say" that adding is in fact allowed and change `allow_add=true` on the fly. As result you'll see add button (from configureAdd method), but will not be able to use it because at the moment when isEditing is called from CRUDs init method allow_add still is false. Checking for page mode directly in CRUDs init method fixes this.
