### PR TITLE
fix long names

### DIFF
--- a/lib/Paginator/Basic.php
+++ b/lib/Paginator/Basic.php
@@ -30,7 +30,11 @@ class Paginator_Basic extends CompleteLister {
 
     function init(){
         parent::init();
-        if(!$this->skip_var)$this->skip_var=$this->name.'_skip';
+        
+        if (!$this->skip_var) {
+            $this->skip_var = $this->name . '_skip';
+        }
+        $this->skip_var = $this->_shorten($this->skip_var);
     }
 
     /** Set number of items displayed per page */


### PR DESCRIPTION
In case object name already is very long we can't simply append more text to it.
Name shortening should always be done. Otherwise in some situations we get into very nasty issues when script works on dev machine, but strangly doesn't work on production site (which has longer URL and longer object names).

Same issue is with grid sorting where simply `_sort` is appended to parameter. It's not yet fixed.