### PR TITLE
fix memorizing of requested URL (4.2)

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -401,7 +401,7 @@ class Auth_Basic extends AbstractController {
     }
     /** Memorize current URL. Called when the first unsuccessful check is executed. */
     function memorizeURL(){
-        if(!$this->recall('page',false)){
+        if($this->api->page !== 'index' && !$this->recall('page',false)){
             $this->memorize('page',$this->api->page);
             $g=$_GET;unset($g['page']);
             $this->memorize('args',$g);
@@ -415,7 +415,7 @@ class Auth_Basic extends AbstractController {
         if($p=='login')return $this->api->url('/');
 
         $url=$this->api->url($p, $this->recall('args',null));
-        $this->forget('url');$this->forget('args');
+        $this->forget('page');$this->forget('args');
         return $url;
     }
     /** Rederect to page user tried to access before authentication was requested */


### PR DESCRIPTION
* if requested page is index and it's protected, then we should not memorize it. It's default page anyway after login. Otherwise it always gets memorized first after logout + redirect to root and manually entered URL is never memorized and redirect to it doesn't work.
* small bug-fix - should be `forget('page')`, not `forget('url')`

See Skype discussion for more info.