### PR TITLE
Fix "like" and boolean values (for 4.3 / master)

### DIFF
--- a/lib/SQL/Model.php
+++ b/lib/SQL/Model.php
@@ -371,7 +371,7 @@ class SQL_Model extends Model implements Serializable {
             $value = $cond;
             $cond = '=';
         }
-        if ($field->type() == 'boolean') {
+        if ($field->type() == 'boolean' && strtolower($cond) !== 'like') {
             $value = $field->getBooleanValue($value);
         }
 


### PR DESCRIPTION
$m->addCondition('boolean_field', 'like', '%123456%');
created incorrect SQL
SELECT * FROM t WHERE boolean_field like 1
instead of slightly more correct
SELECT * FROM t WHERE boolean_field like '%123456%'