### PR TITLE
Don't hardcode ID field name in Grid / CRUD (for 4.2)

### DIFF
--- a/lib/Grid/Advanced.php
+++ b/lib/Grid/Advanced.php
@@ -746,7 +746,7 @@ class Grid_Advanced extends Grid_Basic
                         'cut_page' => 1,
                         // TODO: id is obsolete
                         //'id' => $this->model->id,
-                        $this->columns[$field]['refid'].'_id' => $this->model->id
+                        $this->columns[$field]['refid'].'_'.$this->model->id_field => $this->model->id
                     )
                 ).'" '.
             '/>'.

--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -306,7 +306,7 @@ class View_CRUD extends View
         
         if ($this->isEditing('ex_'.$s)) {
 
-            $idfield=$this->grid->columns['ex_'.$s]['refid'].'_id';
+            $idfield=$this->grid->columns['ex_'.$s]['refid'].'_'.$this->model->id_field;
             if ($_GET[$idfield]) {
                 $this->id = $_GET[$idfield];
                 $this->api->stickyGET($idfield);


### PR DESCRIPTION
Sometimes you need to create nested expanders which can use same DB table, but different ID field. In such situation nested expander owerwrite parent parameters.
So it's better to not hard-code ID field name in here.