### PR TITLE
Don't hardcode ID field name in Grid / CRUD (for master/4.3)

### DIFF
--- a/lib/Grid/Advanced.php
+++ b/lib/Grid/Advanced.php
@@ -722,7 +722,7 @@ class Grid_Advanced extends Grid_Basic
                         'cut_page' => 1,
                         // TODO: id is obsolete
                         //'id' => $this->model->id,
-                        $this->columns[$field]['refid'].'_id' => $this->model->id
+                        $this->columns[$field]['refid'].'_'.$this->model->id => $this->model->id
                     )
                 ).'" '.
             '/>'.

--- a/lib/View/CRUD.php
+++ b/lib/View/CRUD.php
@@ -332,7 +332,7 @@ class View_CRUD extends View
                 $this->api->stickyGET($n);
             }
 
-            $idfield=$this->model->table.'_id';
+            $idfield=$this->model->table.'_'.$this->model->id_field;
             if ($_GET[$idfield]) {
                 $this->id = $_GET[$idfield];
                 $this->api->stickyGET($idfield);
@@ -358,7 +358,7 @@ class View_CRUD extends View
             $this->grid->addColumn('expander', 'ex_'.$s, $options['label'] ?: $s);
             $this->grid->columns['ex_'.$s]['page']
                 = $this->virtual_page->getURL('ex_'.$s);
-            $idfield=$this->grid->columns['ex_'.$s]['refid'].'_id';
+            $idfield=$this->grid->columns['ex_'.$s]['refid'].'_'.$this->model->id_field;
         }
 
         if ($this->isEditing()) {


### PR DESCRIPTION
Sometimes you need to create nested expanders which can use same DB table, but different ID field. In such situation nested expander overwrite parent parameters.
So it's better to not hard-code ID field name in here.