### PR TITLE
make UserMenu better

### DIFF
--- a/lib/Layout/Fluid.php
+++ b/lib/Layout/Fluid.php
@@ -46,8 +46,9 @@ class Layout_Fluid extends Layout_Basic {
         parent::init();
         if ($this->template->hasTag('UserMenu')) {
             if(isset($this->app->auth)){
-                $this->user_menu = $this->add('Menu_Horizontal',null,'UserMenu');
-                $this->user_menu->addMenu($this->app->auth->model[$this->app->auth->model->title_field])->addItem('Logout','logout');
+                $this->user_menu = $this->add('Menu_Horizontal',null,'UserMenu')
+                    ->addMenu($this->app->auth->model[$this->app->auth->model->title_field]);
+                $this->user_menu->addItem('Logout','logout');
             } else {
                 $this->template->tryDel('UserMenu');
                 $this->template->tryDel('user_icon');


### PR DESCRIPTION
$app->user_menu should not be top level menu_horizontal, but sub-menu with username itself.
This way we can add more items in this submenu (dropdown) not top level horizontal menu (which is not appropriate).

Something like this in Frontent for example:

    $app->layout->user_menu->addItem('Profile','profile');
