### PR TITLE
Fix jUI dialog to not block windowed editors

### DIFF
--- a/public/atk4/js/atk4_univ_jui.js
+++ b/public/atk4/js/atk4_univ_jui.js
@@ -186,3 +186,35 @@ $.ui.dialog.prototype._create = function(){
 
 
 
+/**
+ * _allowInteraction fix to accommodate windowed editors
+ * 
+ * This is blocker issue if you want to open CKEditor or TinyMCE editor dialog
+ * from JUI dialog because JUI doesn't give focus outside of it's dialog window.
+ 
+ * @url http://bugs.jqueryui.com/ticket/9087#comment:39
+ * @url https://learn.jquery.com/jquery-ui/widget-factory/extending-widgets/#using-_super-and-_superapply-to-access-parents
+ * @note Tested on jQuery UI v1.11.x
+ */
+$.widget( "ui.dialog", $.ui.dialog, {
+    _allowInteraction: function( event ) {
+        if ( this._super( event ) ) {
+            return true;
+        }
+
+        // address interaction issues with general iframes with the dialog
+        if ( event.target.ownerDocument != this.document[ 0 ] ) {
+            return true;
+        }
+
+        // address interaction issues with dialog window
+        if ( !!$( event.target ).closest( ".cke_dialog, .mce-window, .moxman-window" ).length ) {
+            return true;
+        }
+
+        // address interaction issues with iframe based drop downs in IE
+        if ( !!$( event.target ).closest( ".cke" ).length ) {
+            return true;
+        }
+    }
+});


### PR DESCRIPTION
See comment in source code.
I guess it's important to have this fix here - it's not that easy to find / make and nor jUI developers nor CKEditor or TinyMCE editor developers will fix this. So, it would be good if ATK4 fix this nasty issue once and for all out-of-the-box :)