### PR TITLE
grid formatter changes, abstract formatter class, backward-slash support

### DIFF
--- a/lib/Controller/Grid/Format.php
+++ b/lib/Controller/Grid/Format.php
@@ -1,0 +1,24 @@
+<?php
+abstract class Controller_Grid_Format extends AbstractController{
+    /**
+     * Initialize field
+     *
+     * @param string $name Field name
+     * @param string $descr Field title
+     *
+     * @return void
+     */
+    public function initField($name, $descr) {
+    }
+    
+    /**
+     * Format output of cell in particular row
+     *
+     * @param string $field Field name
+     * @param array $column Array [type=>string, descr=>string]
+     *
+     * @return void
+     */
+    public function formatField($field, $column) {
+    }
+}

--- a/lib/Controller/Grid/Format.php
+++ b/lib/Controller/Grid/Format.php
@@ -3,6 +3,8 @@ abstract class Controller_Grid_Format extends AbstractController{
     /**
      * Initialize field
      *
+     * Note: $this->owner is Grid object
+     * 
      * @param string $name Field name
      * @param string $descr Field title
      *
@@ -14,6 +16,8 @@ abstract class Controller_Grid_Format extends AbstractController{
     /**
      * Format output of cell in particular row
      *
+     * Note: $this->owner is Grid object
+     * 
      * @param string $field Field name
      * @param array $column Array [type=>string, descr=>string]
      *

--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -101,7 +101,7 @@ class Grid_Basic extends CompleteLister
      * @param string $name
      * @param string $descr
      *
-     * @return $this || Controller_Grid_Format_Abstract
+     * @return $this || Controller_Grid_Format
      */
     function addColumn($formatters, $name = null, $descr = null)
     {
@@ -295,7 +295,7 @@ class Grid_Basic extends CompleteLister
      * @param mixed $formatter
      * @param array $options
      *
-     * @return $this || Controller_Grid_Format_Abstract
+     * @return $this || Controller_Grid_Format
      */
     function addFormatter($field, $formatter, $options = null)
     {

--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -155,6 +155,10 @@ class Grid_Basic extends CompleteLister
                 }
 
                 $addon = $this->getElement($subtype.'_'.$name);
+                if (! $addon instanceof Controller_Grid_Format) {
+                    throw $this->exception('Grid formatter class should extend Controller_Grid_Format class')
+                        ->addMoreInfo('formater', $subtype);
+                }
                 $addon->initField($name, $descr);
                 return $addon;
 
@@ -319,6 +323,10 @@ class Grid_Basic extends CompleteLister
             }
 
             $addon = $this->getElement($formatter.'_'.$field);
+            if (! $addon instanceof Controller_Grid_Format) {
+                throw $this->exception('Grid formatter class should extend Controller_Grid_Format class')
+                    ->addMoreInfo('formater', $subtype);
+            }
             $addon->initField($field, $descr);
             return $addon;
 

--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -325,7 +325,7 @@ class Grid_Basic extends CompleteLister
             $addon = $this->getElement($formatter.'_'.$field);
             if (! $addon instanceof Controller_Grid_Format) {
                 throw $this->exception('Grid formatter class should extend Controller_Grid_Format class')
-                    ->addMoreInfo('formater', $subtype);
+                    ->addMoreInfo('formater', $formatter);
             }
             $addon->initField($field, $descr);
             return $addon;
@@ -551,7 +551,7 @@ class Grid_Basic extends CompleteLister
             if ($this->hasMethod($m = $formatter_prefix . $formatter)) {
                 // formatter method is included in this class
                 $this->$m($field, $column);
-            } elseif (strpos($formatter, '/')) {
+            } elseif (strpos($formatter, '\\') || strpos($formatter, '/')) {
                 // add-on support:
                 // http://agiletoolkit.org/codepad/gui/grid#codepad_gui_grid_view_example_7_ex
                 $this->getElement($formatter.'_'.$field)

--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -145,7 +145,7 @@ class Grid_Basic extends CompleteLister
         // TODO call addFormatter instead!
         $subtypes = explode(',', $formatters);
         foreach ($subtypes as $subtype) {
-            if (strpos($subtype, '/')) {
+            if (strpos($subtype, '\\') || strpos($subtype, '/')) {
 
                 // add-on functionality:
                 // http://agiletoolkit.org/codepad/gui/grid#codepad_gui_grid_view_example_7_ex
@@ -310,7 +310,7 @@ class Grid_Basic extends CompleteLister
         $descr = $this->columns[$field];
 
 
-        if (strpos($formatter, '/')) {
+        if (strpos($formatter, '\\') || strpos($formatter, '/')) {
             // add-on functionality:
             // http://agiletoolkit.org/codepad/gui/grid#codepad_gui_grid_view_example_7_ex
             if (!$this->elements[$formatter.'_'.$field]) {

--- a/lib/Grid/Basic.php
+++ b/lib/Grid/Basic.php
@@ -101,7 +101,7 @@ class Grid_Basic extends CompleteLister
      * @param string $name
      * @param string $descr
      *
-     * @return $this
+     * @return $this || Controller_Grid_Format_Abstract
      */
     function addColumn($formatters, $name = null, $descr = null)
     {
@@ -291,7 +291,7 @@ class Grid_Basic extends CompleteLister
      * @param mixed $formatter
      * @param array $options
      *
-     * @return $this
+     * @return $this || Controller_Grid_Format_Abstract
      */
     function addFormatter($field, $formatter, $options = null)
     {


### PR DESCRIPTION
* backward slashes `\` are used in namespaces
* in theory forward slashes `/` shouldn't be used, but we should leave them here for compatibility reasons