### PR TITLE
Update Page.php

### DIFF
--- a/lib/Page.php
+++ b/lib/Page.php
@@ -80,7 +80,7 @@ class Page extends AbstractView {
         $page_name='page/'.strtolower($this->short_name);
         // See if we can locate the page
         try{
-            $p=$this->app->locate('templates',$page_name.'.html');
+            $p=$this->app->locate('template',$page_name.'.html');
         }catch(Exception_PathFinder $e){
             return array('page');
         }


### PR DESCRIPTION
The Page class defaultTemplate function ignores project's template/page/pagename.html and always returns an array('page')
because of wrong\obsolete type ('templates' instead of 'template') in locate($type,...) function