### PR TITLE
Cleanup in validation logic

### DIFF
--- a/lib/Form/Basic.php
+++ b/lib/Form/Basic.php
@@ -447,6 +447,7 @@ class Form_Basic extends View implements ArrayAccess
         $this->hook('loadPOST');
         try {
             $this->hook('validate');
+            $this->hook('post-validate');
 
             if (!empty($this->errors)) {
                 return false;
@@ -591,8 +592,9 @@ class Form_Basic extends View implements ArrayAccess
     {
         if (!$this->validator) {
             $this->validator = $this->add('Controller_Validator');
+            $this->validator->on('post-validate');
         }
-        $this->validator->is($rule)->on('validate');
+        $this->validator->is($rule);
     }
 
     /**

--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -54,7 +54,7 @@ abstract class Form_Field extends AbstractView
     public function setForm($form)
     {
         $form->addHook('loadPOST', $this);
-        $form->addHook('validate', $this);
+        $form->addHook('validate', [$this,'performValidation']);
         $this->form = $form;
         $this->form->data[$this->short_name] = ($this->value !== null ? $this->value : $this->default_value);
         $this->value = &$this->form->data[$this->short_name];
@@ -304,6 +304,15 @@ abstract class Form_Field extends AbstractView
 
         return $this;
     }
+
+    /**
+     * Used to be called validate(), this method is called when
+     * field should do some of it's basic validation done.
+     */
+    function performValidation(){
+
+    }
+
     /** @private - handles field validation callback output */
     public function _validateField($caller, $condition, $msg)
     {

--- a/lib/Form/Field/Number.php
+++ b/lib/Form/Field/Number.php
@@ -4,9 +4,9 @@
  */
 class Form_Field_Number extends Form_Field_Line
 {
-    public function setForm($form)
+    public function performValidation()
     {
-        parent::setForm($form);
+        parent::performValidation();
         $this->validate('number');
     }
 }


### PR DESCRIPTION
This PR cleans up how Agile Toolkit validation works.

1. You may call `$field->validate('number');` sometime after you have created your form
2. If you validate multiple field, the order how you define validate is important.
3. Fields can also define some validations on their own. They can use method `performValidation`
4. If you been redefining validate() on your field in the past and it broke, rename it to `performValidation`
5. Form's validator is tied to 'post-validate' hook, which means you can add last-minute checks thorough `validate` hook.
6. Previously `on()` method would be called multiple times causing validator to fire repeatedly. Now it's done only once
7. Field_Number will no longer be the first one to show it's error on the form.