### PR TITLE
add index 0 since hook method return array

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -825,7 +825,7 @@ class Auth_Basic extends AbstractController
         $this->app->page_object = $p;
 
         // hook: createForm use this to build basic login form
-        $this->form = $this->hook('createForm', array($p));
+        $this->form = $this->hook('createForm', array($p))[0];
 
         // If no hook, build standard form
         if (!is_object($this->form)) {


### PR DESCRIPTION
call to hook ‘createForm’ will return an array, with the form at index
0, instead of the form object. Therefore to properly assign $this-form
from the returning method, we need to use index 0 of the return array.

ex: 
$auth->addHook('createForm', function($auth, $page) use ($self) {
			$f = $page->add('Form', 'f', null, ['form/stacked']);
			$f->addField('email');
			$f->addField('password', 'password');
			$f->addSubmit();
			return $f;
		});