### PR TITLE
Fix Auth_Basic

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -497,9 +497,7 @@ class Auth_Basic extends AbstractController
 
         // Attempt to load user data by username. If not found, return false
         /** @type Model $data User model */
-        $data = $this->model->newInstance();
-        $data->controller = $this->model->controller;
-        $data->_table = $this->model->_table;
+        $data = clone $this->model;
 
         $data->tryLoadBy($this->login_field, $user);
         if (!$data->loaded()) {

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -120,12 +120,12 @@ class Auth_Basic extends AbstractController
         }
         /** @type Model $m */
         $m = $this->add('Model');
+        $m->id_field = $this->login_field;
         $m->setSource('Array', array(
                 is_array($user)
                 ? $user
                 : array($this->login_field => $user, $this->password_field => $pass)
             ));
-        $m->id_field = $this->login_field;
         $this->setModel($m);
 
         return $this;

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -498,6 +498,8 @@ class Auth_Basic extends AbstractController
         // Attempt to load user data by username. If not found, return false
         /** @type Model $data User model */
         $data = $this->model->newInstance();
+        $data->controller = $this->model->controller;
+        $data->_table = $this->model->_table;
 
         $data->tryLoadBy($this->login_field, $user);
         if (!$data->loaded()) {


### PR DESCRIPTION
Simple test case - don't use DB models:
```
$this->add('Auth')->allow('admin', 'secret')->check();
```

1. `$model_id_field` should be set before setSource, because controller should already know which is id_field at this point.
2. use clone instead of newInstance() in Auth->verifyCredentials, because we need to clone controller, _table and other properties of model. newInstance loose them all and authorization doesn't work.