### PR TITLE
fix implode error for php 7.0

### DIFF
--- a/lib/DB/dsql.php
+++ b/lib/DB/dsql.php
@@ -1204,6 +1204,8 @@ class DB_dsql extends AbstractModel implements Iterator
      */
     public function render_options()
     {
+        if(!isset($this->args['options']))
+            return "";
         return @implode(' ', $this->args['options']);
     }
 


### PR DESCRIPTION
Application Error: Warning: [D:\OpenServer\domains\smbo2.loc\vendor\atk4\atk4\lib\DB/<b>dsql.php</b>:1209]implode(): Invalid arguments passed