### PR TITLE
Form field hint should go below field not after

### DIFF
--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -280,13 +280,13 @@ abstract class Form_Field extends AbstractView
     }
     public function setFieldHint($var_args = null)
     {
-        /* Adds a hint after this field. Thes will call Field_Hint->set()
-           with same arguments you called this funciton.
+        /* Adds a hint after this field. This will call Field_Hint->set()
+           with same arguments you called this function.
          */
         if (!$this->template->hasTag('after_field')) {
             return $this;
         }
-        $hint = $this->add('Form_Hint', null, 'after_field');
+        $hint = $this->add('Form_Hint', null, 'below_field');
         call_user_func_array(array($hint, 'set'), func_get_args());
 
         return $this;

--- a/lib/Form/Field.php
+++ b/lib/Form/Field.php
@@ -280,10 +280,10 @@ abstract class Form_Field extends AbstractView
     }
     public function setFieldHint($var_args = null)
     {
-        /* Adds a hint after this field. This will call Field_Hint->set()
+        /* Adds a hint below this field. This will call Form_Hint->set()
            with same arguments you called this function.
          */
-        if (!$this->template->hasTag('after_field')) {
+        if (!$this->template->hasTag('below_field')) {
             return $this;
         }
         $hint = $this->add('Form_Hint', null, 'below_field');


### PR DESCRIPTION
This is especially important, if you addButton() to field.
addButton will reside in after_field template tag and if you also have field hint, then it'll mess design when attached to the same template tag where button (after_field).