### PR TITLE
Auth: fix default field name usage

### DIFF
--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -10,7 +10,7 @@
  * $auth->usePasswordEncryption();
  * $auth->setModel('User');
  * $auth->check();
- * 
+ *
  * and add $this->app->auth->addEncryptionHook($this); in init method of your User model.
  *
  * Auth accessible from anywhere through $this->app->auth;

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -143,11 +143,17 @@ class Auth_Basic extends AbstractController
      *
      * @return Model
      */
-    public function setModel($model, $login_field = 'email', $password_field = 'password')
+    public function setModel($model, $login_field = null, $password_field = null)
     {
         parent::setModel($model);
-        $this->login_field = $login_field;
-        $this->password_field = $password_field;
+
+        // Set login field and password field or use default ones
+        if ($login_field !== null) {
+            $this->login_field = $login_field;
+        }
+        if ($password_field !== null) {
+            $this->password_field = $password_field;
+        }
 
         // Load model from session
         if ($this->info && $this->recall('id')) {

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -4,12 +4,14 @@
  * on a page. You may have multiple Auth instances. Supports
  * 3rd party plugins.
  *
- * Use:
+ * Use like this in your App class:
  *
  * $auth=$this->add('Auth');
  * $auth->usePasswordEncryption();
  * $auth->setModel('User');
  * $auth->check();
+ * 
+ * and add $this->app->auth->addEncryptionHook($this); in init method of your User model.
  *
  * Auth accessible from anywhere through $this->app->auth;
  *


### PR DESCRIPTION
Previously this could be misused like this:

```
$this->add('Auth', ['login_field' => 'login', 'password' => 'mypass']);
$this->auth->setModel('User');
```

This way it still would use default values 'email' and 'password', because they was set as default 2nd and 3rd param values of Auth_Basic::setModel() method.