### PR TITLE
Update PatternRouter.php

### DIFF
--- a/lib/Controller/PatternRouter.php
+++ b/lib/Controller/PatternRouter.php
@@ -131,25 +131,16 @@ class Controller_PatternRouter extends AbstractController
                 return $this;
             }
 
-            $page .= '_';
-
             if (substr($this->app->page, 0, strlen($page)) == $page) {
-                $rest = explode('_', substr($this->app->page, strlen($page)));
+                $_ed =  str_replace('/', '_', $_SERVER['REQUEST_URI']);
+                $path = substr($_SERVER['REQUEST_URI'], strpos($_ed,$this->app->page));
+                $rest = explode('/',  substr($path, strlen($page)+1, strpos($path,'?')-strlen($path)));
 
-                reset($args);
-                foreach ($rest as $arg) {
-                    list($key, $match) = each($args);
-                    if (is_numeric($key) || is_null($key)) {
-                        $key = $match;
-                    } else {
-                        if (!preg_match($match, $arg)) {
-                            break 2;
-                        }
-                    }
-                    $_GET[$key] = $arg;
+                foreach ($args as $i=>$arg) {
+                    $_GET[$arg] = $rest[$i];
                 }
 
-                $this->app->page = substr($page, 0, -1);
+                $this->app->page = $page;
 
                 return $this;
             }

--- a/lib/Controller/PatternRouter.php
+++ b/lib/Controller/PatternRouter.php
@@ -134,7 +134,10 @@ class Controller_PatternRouter extends AbstractController
             if (substr($this->app->page, 0, strlen($page)) == $page) {
                 $_ed =  str_replace('/', '_', $_SERVER['REQUEST_URI']);
                 $path = substr($_SERVER['REQUEST_URI'], strpos($_ed,$this->app->page));
-                $rest = explode('/',  substr($path, strlen($page)+1, strpos($path,'?')-strlen($path)));
+                $rest = (strpos($path,'?'))
+                    ? explode('/',  substr($path, strlen($page)+1, strpos($path,'?')-strlen($path)))
+                    : explode('/',  substr($path, strlen($page)+1))
+                ;
 
                 foreach ($args as $i=>$arg) {
                     $_GET[$arg] = $rest[$i];


### PR DESCRIPTION
when you got
$router->link('v1/accident',array('id','method','user_id'))
you expect
Array ( [id] => 3 [method] => accept_cancel [user_id] => 231 ) 

but if you use "_" in any parameter
api/v1/accident/3/accept_cancel/231
                        ^ it will give you a bug
Array ( [id] => 3 [method] => accept [user_id] => cancel [] => 231 ) 

so...


and can someone explain me the purpose of code below?
especially line with ...!preg_match($match... - in any case it must produce error like "Delimiter must not be alphanumeric or backslash"

reset($args);
foreach ($rest as $arg) {
	list($key, $match) = each($args);
	if (is_numeric($key) || is_null($key)) {
		$key = $match;
	} else {
		if (!preg_match($match, $arg)) {
			break 2;
		}
	}
	$_GET[$key] = $arg;
}